### PR TITLE
fix: Timestamps button visibility and New Game lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Streamn Scoreboard will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-03-21
+
+### Fixed
+- "Copy Timestamps to Clipboard" button now remains visible after OBS restarts or stream stops, as long as `timestamps.txt` exists on disk
+- reeln-cli commands (segment highlights, game highlights) now fire regardless of streaming state — previously the button did nothing when not actively streaming
+
+### Changed
+- New Game clears `timestamps.txt` and hides the copy button
+- Stream start warns if previous game timestamps exist, with option to keep or start fresh
+
 ## [0.4.0] - 2026-03-11
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.21)
 
-project(streamn_obs_scoreboard VERSION 0.4.0 LANGUAGES C CXX)
+project(streamn_obs_scoreboard VERSION 0.4.1 LANGUAGES C CXX)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/include/scoreboard-core.h
+++ b/include/scoreboard-core.h
@@ -216,6 +216,8 @@ int scoreboard_event_log_find_last(const char *prefix);
 int scoreboard_event_log_count(void);
 const struct scoreboard_game_event *scoreboard_event_log_get(int index);
 bool scoreboard_event_log_write(const char *path);
+bool scoreboard_event_log_file_has_content(const char *path);
+int scoreboard_event_log_read(const char *path);
 
 #ifdef __cplusplus
 }

--- a/src/plugin-dock.cpp
+++ b/src/plugin-dock.cpp
@@ -40,6 +40,7 @@
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QLineEdit>
 #include <QtWidgets/QMenu>
+#include <QtWidgets/QMessageBox>
 #include <QtWidgets/QPlainTextEdit>
 #include <QtWidgets/QProgressBar>
 #include <QtWidgets/QPushButton>
@@ -747,30 +748,42 @@ void log_game_end_event()
 	add_recording_chapter(buf);
 }
 
-void write_timestamps_file()
+bool timestamps_file_path(char *buf, size_t size)
 {
 	const char *dir = scoreboard_get_output_directory();
 	if (dir[0] == '\0')
-		return;
+		return false;
+	snprintf(buf, size, "%s/timestamps.txt", dir);
+	return true;
+}
+
+void write_timestamps_file()
+{
 	char path[544]; /* 512 (max output dir) + 32 (filename) */
-	snprintf(path, sizeof(path), "%s/timestamps.txt", dir);
+	if (!timestamps_file_path(path, sizeof(path)))
+		return;
 	scoreboard_event_log_write(path);
 }
 
 void update_copy_timestamps_visibility()
 {
-	if (g_copy_timestamps_btn)
-		g_copy_timestamps_btn->setVisible(
-			scoreboard_event_log_count() > 0);
+	if (!g_copy_timestamps_btn)
+		return;
+	if (scoreboard_event_log_count() > 0) {
+		g_copy_timestamps_btn->setVisible(true);
+		return;
+	}
+	char path[544];
+	if (timestamps_file_path(path, sizeof(path)) &&
+	    scoreboard_event_log_file_has_content(path)) {
+		g_copy_timestamps_btn->setVisible(true);
+		return;
+	}
+	g_copy_timestamps_btn->setVisible(false);
 }
 
 void run_reeln_segment_command()
 {
-	/* Only run the CLI when OBS is actively streaming/recording —
-	   the segment command needs replay files which only exist
-	   during a live session. */
-	if (!g_stream_active)
-		return;
 	const QString executable =
 		QString::fromUtf8(scoreboard_get_cli_executable()).trimmed();
 	if (executable.isEmpty())
@@ -1909,6 +1922,7 @@ void on_frontend_event(enum obs_frontend_event event, void *private_data)
 		rebuild_file_watcher();
 		update_all_labels();
 		update_highlights_button_visibility();
+		update_copy_timestamps_visibility();
 	}
 	/* OBS frontend events and Qt button/hotkey callbacks all run on the
 	   main (Qt) thread, so g_stream_active and g_stream_timer are safe
@@ -1917,8 +1931,46 @@ void on_frontend_event(enum obs_frontend_event event, void *private_data)
 		g_stream_timer.start();
 		g_stream_active = true;
 		g_period_start_logged = -1;
-		scoreboard_event_log_clear();
-		log_event("Stream Start");
+
+		char ts_path[544];
+		bool has_prev = timestamps_file_path(ts_path, sizeof(ts_path)) &&
+				scoreboard_event_log_file_has_content(ts_path);
+
+		if (has_prev) {
+			/* Defer dialog so we don't block the OBS frontend
+			   event callback */
+			QString saved_path = QString::fromUtf8(ts_path);
+			QTimer::singleShot(0, [saved_path]() {
+				QMessageBox box(g_dock_widget);
+				box.setWindowTitle("Previous Timestamps");
+				box.setText(
+					"Timestamps from a previous game exist.\n"
+					"Start fresh or keep them?");
+				box.setIcon(QMessageBox::Question);
+				QPushButton *fresh = box.addButton(
+					"Start Fresh",
+					QMessageBox::AcceptRole);
+				box.addButton("Keep",
+					      QMessageBox::RejectRole);
+				box.setDefaultButton(fresh);
+				box.exec();
+
+				if (box.clickedButton() == fresh) {
+					scoreboard_event_log_clear();
+					log_event("Stream Start");
+				} else {
+					scoreboard_event_log_read(
+						saved_path.toUtf8()
+							.constData());
+				}
+				update_copy_timestamps_visibility();
+			});
+		} else {
+			scoreboard_event_log_clear();
+			log_event("Stream Start");
+			update_copy_timestamps_visibility();
+		}
+
 		log_info("[streamn-obs-scoreboard] streaming started — "
 			 "event timestamps enabled");
 	}
@@ -2553,27 +2605,42 @@ bool scoreboard_dock_init(scoreboard_log_fn log_fn)
 	QObject::connect(g_game_finished, &QCheckBox::toggled,
 			 []() { update_all_labels(); });
 	QObject::connect(g_copy_timestamps_btn, &QPushButton::clicked, []() {
-		/* Build YouTube chapters text from event log */
 		QString text;
 		int count = scoreboard_event_log_count();
-		for (int i = 0; i < count; i++) {
-			const struct scoreboard_game_event *ev =
-				scoreboard_event_log_get(i);
-			if (!ev)
-				continue;
-			int total = ev->offset_seconds;
-			int hours = total / 3600;
-			int minutes = (total % 3600) / 60;
-			int seconds = total % 60;
-			if (!text.isEmpty())
-				text += "\n";
-			text += QString::asprintf("%d:%02d:%02d %s", hours,
-						  minutes, seconds,
-						  ev->label);
+		if (count > 0) {
+			/* Build from in-memory event log */
+			for (int i = 0; i < count; i++) {
+				const struct scoreboard_game_event *ev =
+					scoreboard_event_log_get(i);
+				if (!ev)
+					continue;
+				int total = ev->offset_seconds;
+				int hours = total / 3600;
+				int minutes = (total % 3600) / 60;
+				int seconds = total % 60;
+				if (!text.isEmpty())
+					text += "\n";
+				text += QString::asprintf(
+					"%d:%02d:%02d %s", hours, minutes,
+					seconds, ev->label);
+			}
+		} else {
+			/* Fall back to timestamps.txt on disk */
+			char path[544];
+			if (timestamps_file_path(path, sizeof(path))) {
+				QFile file(QString::fromUtf8(path));
+				if (file.open(QIODevice::ReadOnly |
+					      QIODevice::Text))
+					text = QString::fromUtf8(
+						       file.readAll())
+						       .trimmed();
+			}
 		}
-		QGuiApplication::clipboard()->setText(text);
-		log_info("[streamn-obs-scoreboard] timestamps copied to "
-			 "clipboard");
+		if (!text.isEmpty()) {
+			QGuiApplication::clipboard()->setText(text);
+			log_info("[streamn-obs-scoreboard] timestamps "
+				 "copied to clipboard");
+		}
 	});
 	/* Penalty clear buttons are connected dynamically in update_all_labels */
 
@@ -2586,6 +2653,7 @@ bool scoreboard_dock_init(scoreboard_log_fn log_fn)
 		scoreboard_new_game();
 		g_period_start_logged = -1;
 		scoreboard_event_log_clear();
+		write_timestamps_file();
 		update_copy_timestamps_visibility();
 		update_all_labels();
 	});

--- a/src/scoreboard-core.c
+++ b/src/scoreboard-core.c
@@ -1597,3 +1597,55 @@ bool scoreboard_event_log_write(const char *path)
 	fclose(f);
 	return true;
 }
+
+bool scoreboard_event_log_file_has_content(const char *path)
+{
+	if (path == NULL)
+		return false;
+	FILE *f = fopen(path, "r");
+	if (f == NULL)
+		return false;
+	fseek(f, 0, SEEK_END);
+	long size = ftell(f);
+	fclose(f);
+	return size > 0;
+}
+
+int scoreboard_event_log_read(const char *path)
+{
+	if (path == NULL)
+		return -1;
+	FILE *f = fopen(path, "r");
+	if (f == NULL)
+		return -1;
+
+	int loaded = 0;
+	char line[256];
+	while (fgets(line, sizeof(line), f) != NULL) {
+		/* Strip trailing newline */
+		size_t len = strlen(line);
+		if (len > 0 && line[len - 1] == '\n')
+			line[len - 1] = '\0';
+
+		/* Parse "H:MM:SS label" format */
+		int hours = 0, minutes = 0, seconds = 0;
+		int consumed = 0;
+		if (sscanf(line, "%d:%d:%d %n", &hours, &minutes, &seconds,
+			   &consumed) < 3 ||
+		    consumed == 0) {
+			continue; /* skip malformed lines */
+		}
+
+		const char *label = line + consumed;
+		if (label[0] == '\0')
+			continue;
+
+		int offset = hours * 3600 + minutes * 60 + seconds;
+		if (scoreboard_event_log_add(offset, label) < 0)
+			break; /* capacity reached */
+		loaded++;
+	}
+
+	fclose(f);
+	return loaded;
+}

--- a/tests/test-scoreboard-core-events.c
+++ b/tests/test-scoreboard-core-events.c
@@ -409,6 +409,240 @@ static void test_event_log_find_last_empty_prefix(void)
 	assert(scoreboard_event_log_find_last("") == -1);
 }
 
+static void test_event_log_file_has_content(void)
+{
+	scoreboard_reset_state_for_tests();
+	setup_tmp_dir();
+
+	char path[512];
+	snprintf(path, sizeof(path), "%s/timestamps_hc.txt", g_tmp_dir);
+
+	/* Write a file with content */
+	FILE *f = fopen(path, "w");
+	assert(f != NULL);
+	fprintf(f, "0:00:00 Stream Start\n");
+	fclose(f);
+
+	assert(scoreboard_event_log_file_has_content(path));
+
+	cleanup_tmp_dir();
+}
+
+static void test_event_log_file_has_content_empty(void)
+{
+	scoreboard_reset_state_for_tests();
+	setup_tmp_dir();
+
+	char path[512];
+	snprintf(path, sizeof(path), "%s/timestamps_empty_hc.txt", g_tmp_dir);
+
+	/* Write an empty file */
+	FILE *f = fopen(path, "w");
+	assert(f != NULL);
+	fclose(f);
+
+	assert(!scoreboard_event_log_file_has_content(path));
+
+	cleanup_tmp_dir();
+}
+
+static void test_event_log_file_has_content_missing(void)
+{
+	assert(!scoreboard_event_log_file_has_content(
+		"/nonexistent/path/timestamps.txt"));
+}
+
+static void test_event_log_file_has_content_null(void)
+{
+	assert(!scoreboard_event_log_file_has_content(NULL));
+}
+
+static void test_event_log_read_basic(void)
+{
+	scoreboard_reset_state_for_tests();
+	setup_tmp_dir();
+
+	/* Add events and write them out */
+	scoreboard_event_log_add(0, "Stream Start");
+	scoreboard_event_log_add(754, "Period 1 Start");
+	scoreboard_event_log_add(3661, "Goal: Eagles (1-0)");
+
+	char path[512];
+	snprintf(path, sizeof(path), "%s/timestamps_read.txt", g_tmp_dir);
+	assert(scoreboard_event_log_write(path));
+
+	/* Clear and read back */
+	scoreboard_event_log_clear();
+	assert(scoreboard_event_log_count() == 0);
+
+	int loaded = scoreboard_event_log_read(path);
+	assert(loaded == 3);
+	assert(scoreboard_event_log_count() == 3);
+
+	const struct scoreboard_game_event *ev = scoreboard_event_log_get(0);
+	assert(ev->offset_seconds == 0);
+	assert(strcmp(ev->label, "Stream Start") == 0);
+
+	ev = scoreboard_event_log_get(1);
+	assert(ev->offset_seconds == 754);
+	assert(strcmp(ev->label, "Period 1 Start") == 0);
+
+	ev = scoreboard_event_log_get(2);
+	assert(ev->offset_seconds == 3661);
+	assert(strcmp(ev->label, "Goal: Eagles (1-0)") == 0);
+
+	cleanup_tmp_dir();
+}
+
+static void test_event_log_read_empty_file(void)
+{
+	scoreboard_reset_state_for_tests();
+	setup_tmp_dir();
+
+	char path[512];
+	snprintf(path, sizeof(path), "%s/timestamps_read_empty.txt", g_tmp_dir);
+
+	FILE *f = fopen(path, "w");
+	assert(f != NULL);
+	fclose(f);
+
+	int loaded = scoreboard_event_log_read(path);
+	assert(loaded == 0);
+	assert(scoreboard_event_log_count() == 0);
+
+	cleanup_tmp_dir();
+}
+
+static void test_event_log_read_bad_path(void)
+{
+	scoreboard_reset_state_for_tests();
+	int loaded = scoreboard_event_log_read("/nonexistent/dir/file.txt");
+	assert(loaded == -1);
+}
+
+static void test_event_log_read_null_path(void)
+{
+	scoreboard_reset_state_for_tests();
+	int loaded = scoreboard_event_log_read(NULL);
+	assert(loaded == -1);
+}
+
+static void test_event_log_read_malformed_lines(void)
+{
+	scoreboard_reset_state_for_tests();
+	setup_tmp_dir();
+
+	char path[512];
+	snprintf(path, sizeof(path), "%s/timestamps_malformed.txt", g_tmp_dir);
+
+	FILE *f = fopen(path, "w");
+	assert(f != NULL);
+	fprintf(f, "0:00:00 Stream Start\n");
+	fprintf(f, "this is not a valid line\n");
+	fprintf(f, "\n");
+	fprintf(f, "0:12:34 Period 1 Start\n");
+	fprintf(f, "abc:de:fg Bad Time\n");
+	fclose(f);
+
+	int loaded = scoreboard_event_log_read(path);
+	assert(loaded == 2);
+	assert(scoreboard_event_log_count() == 2);
+
+	const struct scoreboard_game_event *ev = scoreboard_event_log_get(0);
+	assert(strcmp(ev->label, "Stream Start") == 0);
+	ev = scoreboard_event_log_get(1);
+	assert(strcmp(ev->label, "Period 1 Start") == 0);
+
+	cleanup_tmp_dir();
+}
+
+static void test_event_log_read_preserves_existing(void)
+{
+	scoreboard_reset_state_for_tests();
+	setup_tmp_dir();
+
+	/* Add an event in memory first */
+	scoreboard_event_log_add(0, "Existing Event");
+	assert(scoreboard_event_log_count() == 1);
+
+	/* Write a file with different events */
+	char path[512];
+	snprintf(path, sizeof(path), "%s/timestamps_preserve.txt", g_tmp_dir);
+
+	FILE *f = fopen(path, "w");
+	assert(f != NULL);
+	fprintf(f, "0:05:00 File Event 1\n");
+	fprintf(f, "0:10:00 File Event 2\n");
+	fclose(f);
+
+	int loaded = scoreboard_event_log_read(path);
+	assert(loaded == 2);
+	assert(scoreboard_event_log_count() == 3);
+
+	/* Original event still first */
+	assert(strcmp(scoreboard_event_log_get(0)->label,
+		     "Existing Event") == 0);
+	assert(strcmp(scoreboard_event_log_get(1)->label,
+		     "File Event 1") == 0);
+	assert(strcmp(scoreboard_event_log_get(2)->label,
+		     "File Event 2") == 0);
+
+	cleanup_tmp_dir();
+}
+
+static void test_event_log_read_empty_label(void)
+{
+	scoreboard_reset_state_for_tests();
+	setup_tmp_dir();
+
+	char path[512];
+	snprintf(path, sizeof(path), "%s/timestamps_emptylabel.txt", g_tmp_dir);
+
+	FILE *f = fopen(path, "w");
+	assert(f != NULL);
+	/* Line with timestamp but no label after the space */
+	fprintf(f, "0:00:00 \n");
+	fprintf(f, "0:01:00 Valid Event\n");
+	fclose(f);
+
+	int loaded = scoreboard_event_log_read(path);
+	assert(loaded == 1);
+	assert(scoreboard_event_log_count() == 1);
+	assert(strcmp(scoreboard_event_log_get(0)->label, "Valid Event") == 0);
+
+	cleanup_tmp_dir();
+}
+
+static void test_event_log_read_capacity_limit(void)
+{
+	scoreboard_reset_state_for_tests();
+	setup_tmp_dir();
+
+	/* Fill event log to capacity */
+	for (int i = 0; i < SCOREBOARD_MAX_EVENTS; i++) {
+		char label[32];
+		snprintf(label, sizeof(label), "Event %d", i);
+		scoreboard_event_log_add(i, label);
+	}
+	assert(scoreboard_event_log_count() == SCOREBOARD_MAX_EVENTS);
+
+	/* Write a file with one more event */
+	char path[512];
+	snprintf(path, sizeof(path), "%s/timestamps_cap.txt", g_tmp_dir);
+
+	FILE *f = fopen(path, "w");
+	assert(f != NULL);
+	fprintf(f, "0:00:00 Overflow Event\n");
+	fclose(f);
+
+	/* Read should stop at capacity */
+	int loaded = scoreboard_event_log_read(path);
+	assert(loaded == 0);
+	assert(scoreboard_event_log_count() == SCOREBOARD_MAX_EVENTS);
+
+	cleanup_tmp_dir();
+}
+
 static void test_event_log_find_and_remove(void)
 {
 	scoreboard_reset_state_for_tests();
@@ -472,6 +706,18 @@ int main(void)
 	test_event_log_find_last_empty_log();
 	test_event_log_find_last_empty_prefix();
 	test_event_log_find_and_remove();
+	test_event_log_file_has_content();
+	test_event_log_file_has_content_empty();
+	test_event_log_file_has_content_missing();
+	test_event_log_file_has_content_null();
+	test_event_log_read_basic();
+	test_event_log_read_empty_file();
+	test_event_log_read_bad_path();
+	test_event_log_read_null_path();
+	test_event_log_read_malformed_lines();
+	test_event_log_read_preserves_existing();
+	test_event_log_read_empty_label();
+	test_event_log_read_capacity_limit();
 	printf("All event log tests passed!\n");
 	return 0;
 }


### PR DESCRIPTION
## Summary

- **Timestamps button persists across OBS restarts** — visibility now checks `timestamps.txt` on disk, not just the in-memory event log
- **Click handler falls back to file** — when in-memory log is empty (e.g. after restart), reads `timestamps.txt` directly and copies to clipboard
- **New Game clears timestamps** — truncates `timestamps.txt` and hides the button
- **Stream start warns about previous timestamps** — shows a "Start Fresh / Keep" dialog so users don't accidentally lose chapter markers from a previous game

## Test plan

- [x] `make build && make test` — all 7 test suites pass
- [x] `make coverage` — 100% line coverage on scoreboard-core
- [ ] Manual: start stream, log events, stop stream, restart OBS → button visible, copy works
- [ ] Manual: click New Game → button disappears, `timestamps.txt` emptied
- [ ] Manual: with timestamps from previous game, start new stream → dialog asks keep/clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)