### PR TITLE
feat: Period labels, faceoff wins, and penalty queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Streamn Scoreboard will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Configurable period labels — period display names are now customizable per-game via `period_labels.txt`, with sport-specific defaults (e.g. hockey: 1, 2, 3, OT, OT2, OT3, OT4)
+- "Edit..." button in Game Settings to open `period_labels.txt` in default text editor for quick customization
+- File watcher on `period_labels.txt` — edits in external editors apply immediately without restarting OBS
+- Faceoff wins counter for hockey and lacrosse — tracks home/away faceoff wins with +/- buttons, displayed below shots on goal
+- `home_faceoffs.txt` and `away_faceoffs.txt` output files for OBS Text sources
+- 4 new OBS hotkeys: Home/Away Faceoff Win +/-
+- Tooltips on all stat row buttons and labels (SOG, FO) for discoverability
+- Penalty queue system — only 2 penalties per team run simultaneously (matching hockey rules), additional penalties queue and auto-start when earlier ones expire
+- `SCOREBOARD_MAX_RUNNING_PENALTIES` constant for configurable penalty concurrency
+
+### Fixed
+- Start/Stop button now resets to green "Start" when clock auto-stops at 0:00 — previously stayed red "Stop" until manually clicked
+- Penalty timers now freeze when period clock reaches 0:00 — previously kept ticking after clock auto-stop
+
+### Changed
+- Period max is now derived from period label count instead of hardcoded segment_count + ot_max
+- Toggling overtime on/off regenerates period labels and clamps current period accordingly
+- Penalty text file output (`home_penalty_numbers.txt`, etc.) now shows only the 2 running penalties, not queued ones
+- Dock UI shows all active penalties but marks queued penalties with "(queued)" suffix
+
 ## [0.4.1] - 2026-03-21
 
 ### Fixed

--- a/include/scoreboard-core.h
+++ b/include/scoreboard-core.h
@@ -40,6 +40,7 @@ struct scoreboard_sport_preset {
 	int duration_seconds;
 	int ot_max;
 	bool has_shots;
+	bool has_faceoffs;
 	bool has_penalties;
 	enum scoreboard_clock_direction default_direction;
 	bool has_fouls;
@@ -47,6 +48,8 @@ struct scoreboard_sport_preset {
 	char foul_label2[16];
 	bool log_scores;
 	char score_label[16];
+	int default_penalty_secs;
+	int default_major_penalty_secs;
 };
 
 struct scoreboard_penalty {
@@ -87,9 +90,17 @@ void scoreboard_format_period(char *buf, size_t size);
 void scoreboard_set_overtime_enabled(bool enabled);
 bool scoreboard_get_overtime_enabled(void);
 
+/* Period labels (configurable per-period display names) */
+void scoreboard_set_period_labels(const char *labels);
+void scoreboard_get_period_labels(char *buf, size_t size);
+int scoreboard_get_period_label_count(void);
+const char *scoreboard_get_period_label(int index);
+
 /* Default penalty duration (seconds) */
 void scoreboard_set_default_penalty_duration(int seconds);
 int scoreboard_get_default_penalty_duration(void);
+void scoreboard_set_default_major_penalty_duration(int seconds);
+int scoreboard_get_default_major_penalty_duration(void);
 
 /* Team names */
 void scoreboard_set_home_name(const char *name);
@@ -117,6 +128,17 @@ void scoreboard_set_away_shots(int shots);
 void scoreboard_increment_away_shots(void);
 void scoreboard_decrement_away_shots(void);
 
+/* Faceoff wins (per-team counter) */
+int scoreboard_get_home_faceoffs(void);
+void scoreboard_set_home_faceoffs(int faceoffs);
+void scoreboard_increment_home_faceoffs(void);
+void scoreboard_decrement_home_faceoffs(void);
+int scoreboard_get_away_faceoffs(void);
+void scoreboard_set_away_faceoffs(int faceoffs);
+void scoreboard_increment_away_faceoffs(void);
+void scoreboard_decrement_away_faceoffs(void);
+bool scoreboard_get_has_faceoffs(void);
+
 /* Fouls / cards / flags (simple per-team counter) */
 int scoreboard_get_home_fouls(void);
 void scoreboard_set_home_fouls(int fouls);
@@ -138,6 +160,9 @@ void scoreboard_increment_away_fouls2(void);
 void scoreboard_decrement_away_fouls2(void);
 
 #define SCOREBOARD_MAX_PENALTIES 8
+#define SCOREBOARD_MAX_RUNNING_PENALTIES 2
+#define SCOREBOARD_MAX_PERIOD_LABELS 16
+#define SCOREBOARD_PERIOD_LABEL_SIZE 16
 
 /* Penalties (up to SCOREBOARD_MAX_PENALTIES per team) */
 int scoreboard_home_penalty_add(int player_number, int duration_secs);

--- a/src/plugin-dock.cpp
+++ b/src/plugin-dock.cpp
@@ -21,7 +21,9 @@
 #include <QtCore/QElapsedTimer>
 #include <QtCore/QFileSystemWatcher>
 #include <QtCore/QTimer>
+#include <QtCore/QUrl>
 #include <QtGui/QClipboard>
+#include <QtGui/QDesktopServices>
 #include <QtGui/QGuiApplication>
 #include <QtGui/QPixmap>
 
@@ -100,6 +102,9 @@ QVBoxLayout *g_away_pen_layout = nullptr;
 QVector<penalty_row_widgets *> g_home_pen_rows;
 QVector<penalty_row_widgets *> g_away_pen_rows;
 QWidget *g_shots_row_widget = nullptr;
+QWidget *g_faceoffs_row_widget = nullptr;
+QLabel *g_home_faceoffs_label = nullptr;
+QLabel *g_away_faceoffs_label = nullptr;
 QWidget *g_fouls_row_widget = nullptr;
 QLabel *g_home_fouls_label = nullptr;
 QLabel *g_away_fouls_label = nullptr;
@@ -151,7 +156,7 @@ struct recording_chapter {
 };
 QVector<recording_chapter> g_recording_chapters;
 
-static const int kNumHotkeys = 31;
+static const int kNumHotkeys = 37;
 
 static const char *kHotkeyNames[kNumHotkeys] = {
 	"sb_clock_startstop",  "sb_clock_reset",
@@ -170,6 +175,9 @@ static const char *kHotkeyNames[kNumHotkeys] = {
 	"sb_away_foul_plus",   "sb_away_foul_minus",
 	"sb_home_foul2_plus",  "sb_home_foul2_minus",
 	"sb_away_foul2_plus",  "sb_away_foul2_minus",
+	"sb_home_major_pen_add", "sb_away_major_pen_add",
+	"sb_home_fo_plus",     "sb_home_fo_minus",
+	"sb_away_fo_plus",     "sb_away_fo_minus",
 };
 
 obs_hotkey_id g_hotkey_ids[kNumHotkeys];
@@ -782,7 +790,7 @@ void update_copy_timestamps_visibility()
 	g_copy_timestamps_btn->setVisible(false);
 }
 
-void run_reeln_segment_command()
+void run_reeln_highlights_command()
 {
 	const QString executable =
 		QString::fromUtf8(scoreboard_get_cli_executable()).trimmed();
@@ -794,21 +802,10 @@ void run_reeln_segment_command()
 	if (!extra.isEmpty())
 		extra_parts = extra.split(' ', Qt::SkipEmptyParts);
 
-	bool game_finished =
-		g_game_finished && g_game_finished->isChecked();
-	if (game_finished) {
-		log_game_end_event();
-		QStringList args;
-		args << "game" << "highlights" << extra_parts;
-		add_job_row("Game Highlights", args);
-	} else {
-		char period_buf[64];
-		scoreboard_format_period(period_buf, sizeof(period_buf));
-		QString period_text = QString::fromUtf8(period_buf);
-		QStringList args;
-		args << "game" << "segment" << period_text << extra_parts;
-		add_job_row("Segment " + period_text, args);
-	}
+	log_game_end_event();
+	QStringList args;
+	args << "game" << "highlights" << extra_parts;
+	add_job_row("Game Highlights", args);
 }
 
 void write_files_now();
@@ -862,6 +859,9 @@ void update_all_labels()
 	}
 	if (g_shots_row_widget)
 		g_shots_row_widget->setVisible(scoreboard_get_has_shots());
+	if (g_faceoffs_row_widget)
+		g_faceoffs_row_widget->setVisible(
+			scoreboard_get_has_faceoffs());
 	if (g_fouls_row_widget)
 		g_fouls_row_widget->setVisible(scoreboard_get_has_fouls());
 	if (g_fouls_center_label)
@@ -908,6 +908,12 @@ void update_all_labels()
 	if (g_away_shots_label)
 		g_away_shots_label->setText(
 			QString::number(scoreboard_get_away_shots()));
+	if (g_home_faceoffs_label)
+		g_home_faceoffs_label->setText(
+			QString::number(scoreboard_get_home_faceoffs()));
+	if (g_away_faceoffs_label)
+		g_away_faceoffs_label->setText(
+			QString::number(scoreboard_get_away_faceoffs()));
 
 	auto update_pen_rows = [](QVBoxLayout *layout,
 				  QVector<penalty_row_widgets *> &rows,
@@ -938,6 +944,7 @@ void update_all_labels()
 
 		/* If slots haven't changed, just update the label text */
 		if (!need_rebuild) {
+			int idx = 0;
 			for (penalty_row_widgets *pw : rows) {
 				char nbuf[32], tbuf[32];
 				scoreboard_format_penalty_number(
@@ -946,9 +953,12 @@ void update_all_labels()
 				scoreboard_format_penalty_time(
 					pw->slot, pw->home, tbuf,
 					sizeof(tbuf));
-				pw->label->setText(
-					QString::fromUtf8(nbuf) + " " +
-					QString::fromUtf8(tbuf));
+				QString text = QString::fromUtf8(nbuf)
+					+ " " + QString::fromUtf8(tbuf);
+				if (idx >= SCOREBOARD_MAX_RUNNING_PENALTIES)
+					text += " (queued)";
+				pw->label->setText(text);
+				idx++;
 			}
 			return;
 		}
@@ -962,6 +972,8 @@ void update_all_labels()
 		}
 		rows.clear();
 
+		QWidget *parent_widget = layout->parentWidget();
+		int row_idx = 0;
 		for (int i : active_slots) {
 			char nbuf[32], tbuf[32];
 			scoreboard_format_penalty_number(i, home, nbuf,
@@ -972,15 +984,18 @@ void update_all_labels()
 			penalty_row_widgets *pw = new penalty_row_widgets();
 			pw->slot = i;
 			pw->home = home;
-			pw->container = new QWidget();
+			pw->container = new QWidget(parent_widget);
 			QHBoxLayout *hl = new QHBoxLayout(pw->container);
 			hl->setContentsMargins(0, 0, 0, 0);
 			hl->setSpacing(4);
 
-			pw->label = new QLabel(
-				QString::fromUtf8(nbuf) + " " +
-				QString::fromUtf8(tbuf));
+			QString text = QString::fromUtf8(nbuf) + " " +
+				QString::fromUtf8(tbuf);
+			if (row_idx >= SCOREBOARD_MAX_RUNNING_PENALTIES)
+				text += " (queued)";
+			pw->label = new QLabel(text);
 			pw->label->setStyleSheet("font-size: 11px;");
+			row_idx++;
 			pw->clear_btn = new QPushButton("X");
 			pw->clear_btn->setFixedSize(18, 18);
 			pw->clear_btn->setStyleSheet(
@@ -1014,6 +1029,8 @@ void update_all_labels()
 			layout->addWidget(pw->container);
 			rows.push_back(pw);
 		}
+		if (parent_widget)
+			parent_widget->adjustSize();
 	};
 
 	update_pen_rows(g_home_pen_layout, g_home_pen_rows, true);
@@ -1025,11 +1042,15 @@ const char *kWatchedFiles[] = {
 	"home_score.txt",	  "away_score.txt",
 	"clock.txt",		  "period.txt",
 	"home_shots.txt",	  "away_shots.txt",
+	"home_faceoffs.txt",	  "away_faceoffs.txt",
 	"home_penalty_numbers.txt", "home_penalty_times.txt",
 	"away_penalty_numbers.txt", "away_penalty_times.txt",
 	"home_fouls.txt",	    "away_fouls.txt",
 	"home_fouls2.txt",	    "away_fouls2.txt",
 	"sport.txt",
+	"default_penalty_duration.txt",
+	"default_major_penalty_duration.txt",
+	"period_labels.txt",
 };
 const int kWatchedFileCount = sizeof(kWatchedFiles) / sizeof(kWatchedFiles[0]);
 const qint64 kWriteCooldownMs = 500;
@@ -1078,10 +1099,14 @@ void write_files_now()
 
 void on_tick()
 {
+	bool was_running = scoreboard_clock_is_running();
 	scoreboard_clock_tick(1);
+	bool is_running = scoreboard_clock_is_running();
 	if (scoreboard_is_dirty())
 		write_files_now();
 	update_all_labels();
+	if (was_running && !is_running && g_clock_btn)
+		g_clock_btn->repaint();
 }
 
 /* ---- Profile paths ---- */
@@ -1145,7 +1170,8 @@ void update_highlights_button_visibility()
 
 /* ---- Dialogs ---- */
 
-void open_add_penalty_dialog(QWidget *parent, bool home)
+void open_add_penalty_dialog(QWidget *parent, bool home,
+			     int default_duration_secs = 0)
 {
 	QDialog dialog(parent);
 	dialog.setWindowTitle(home ? "Add Home Penalty" : "Add Away Penalty");
@@ -1161,8 +1187,11 @@ void open_add_penalty_dialog(QWidget *parent, bool home)
 	QHBoxLayout *dur_row = new QHBoxLayout();
 	dur_row->addWidget(new QLabel("Duration (sec):", &dialog));
 	QSpinBox *dur_spin = new QSpinBox(&dialog);
-	dur_spin->setRange(1, 600);
-	dur_spin->setValue(scoreboard_get_default_penalty_duration());
+	dur_spin->setRange(1, 1200);
+	int dur_val = default_duration_secs > 0
+		? default_duration_secs
+		: scoreboard_get_default_penalty_duration();
+	dur_spin->setValue(dur_val);
 	dur_row->addWidget(dur_spin);
 	layout->addLayout(dur_row);
 
@@ -1294,7 +1323,7 @@ void open_clock_settings_dialog(QWidget *parent)
 	});
 
 	QLabel *pen_dur_label =
-		new QLabel("Default penalty (seconds):", &dialog);
+		new QLabel("Minor penalty (seconds):", &dialog);
 	QHBoxLayout *pen_dur_row = new QHBoxLayout();
 	pen_dur_row->addWidget(pen_dur_label);
 	QSpinBox *pen_dur_spin = new QSpinBox(&dialog);
@@ -1302,6 +1331,17 @@ void open_clock_settings_dialog(QWidget *parent)
 	pen_dur_spin->setValue(scoreboard_get_default_penalty_duration());
 	pen_dur_row->addWidget(pen_dur_spin);
 	layout->addLayout(pen_dur_row);
+
+	QLabel *major_pen_dur_label =
+		new QLabel("Major penalty (seconds):", &dialog);
+	QHBoxLayout *major_pen_dur_row = new QHBoxLayout();
+	major_pen_dur_row->addWidget(major_pen_dur_label);
+	QSpinBox *major_pen_dur_spin = new QSpinBox(&dialog);
+	major_pen_dur_spin->setRange(1, 1200);
+	major_pen_dur_spin->setValue(
+		scoreboard_get_default_major_penalty_duration());
+	major_pen_dur_row->addWidget(major_pen_dur_spin);
+	layout->addLayout(major_pen_dur_row);
 
 	/* Preset duration/direction/features per sport (mirrors core table) */
 	struct sport_ui_info {
@@ -1324,7 +1364,8 @@ void open_clock_settings_dialog(QWidget *parent)
 	QObject::connect(
 		sport_combo, qOverload<int>(&QComboBox::currentIndexChanged),
 		[len_spin, down_btn, up_btn, pen_dur_spin,
-		 pen_dur_label](int index) {
+		 pen_dur_label, major_pen_dur_spin,
+		 major_pen_dur_label](int index) {
 			if (index < 0 || index >= SCOREBOARD_SPORT_COUNT)
 				return;
 			const sport_ui_info &info = k_sport_ui[index];
@@ -1339,7 +1380,38 @@ void open_clock_settings_dialog(QWidget *parent)
 			}
 			pen_dur_label->setVisible(info.has_penalties);
 			pen_dur_spin->setVisible(info.has_penalties);
+			major_pen_dur_label->setVisible(info.has_penalties);
+			major_pen_dur_spin->setVisible(info.has_penalties);
 		});
+
+	/* Period labels button */
+	QHBoxLayout *labels_row = new QHBoxLayout();
+	labels_row->addWidget(new QLabel("Period labels:", &dialog));
+	QPushButton *labels_btn = new QPushButton("Edit...", &dialog);
+	labels_row->addWidget(labels_btn, 1);
+	layout->addLayout(labels_row);
+	QObject::connect(labels_btn, &QPushButton::clicked, [&dialog]() {
+		const char *dir = scoreboard_get_output_directory();
+		if (dir[0] == '\0') {
+			QMessageBox::warning(
+				&dialog, "No Output Directory",
+				"Set an output directory first.");
+			return;
+		}
+		QString path =
+			QString::fromUtf8(dir) + "/period_labels.txt";
+		QFile file(path);
+		if (!file.exists()) {
+			/* Create with current labels so user has a starting point */
+			if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+				char buf[512];
+				scoreboard_get_period_labels(buf, sizeof(buf));
+				file.write(buf);
+				file.close();
+			}
+		}
+		QDesktopServices::openUrl(QUrl::fromLocalFile(path));
+	});
 
 	QFrame *sep = new QFrame(&dialog);
 	sep->setFrameShape(QFrame::HLine);
@@ -1452,6 +1524,8 @@ void open_clock_settings_dialog(QWidget *parent)
 					      : SCOREBOARD_CLOCK_COUNT_UP);
 		scoreboard_set_default_penalty_duration(
 			pen_dur_spin->value());
+		scoreboard_set_default_major_penalty_duration(
+			major_pen_dur_spin->value());
 		scoreboard_set_cli_executable(
 			cli_input->text().trimmed().toUtf8().constData());
 		scoreboard_set_cli_extra_args(
@@ -1631,6 +1705,30 @@ void hk_away_shot_minus(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
 		scoreboard_decrement_away_shots();
 }
 
+void hk_home_fo_plus(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
+{
+	if (pressed)
+		scoreboard_increment_home_faceoffs();
+}
+
+void hk_home_fo_minus(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
+{
+	if (pressed)
+		scoreboard_decrement_home_faceoffs();
+}
+
+void hk_away_fo_plus(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
+{
+	if (pressed)
+		scoreboard_increment_away_faceoffs();
+}
+
+void hk_away_fo_minus(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
+{
+	if (pressed)
+		scoreboard_decrement_away_faceoffs();
+}
+
 void hk_period_advance(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
 {
 	if (!pressed)
@@ -1639,7 +1737,6 @@ void hk_period_advance(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
 		return;
 	log_period_end_event();
 	scoreboard_period_advance();
-	run_reeln_segment_command();
 }
 
 void hk_period_rewind(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
@@ -1708,6 +1805,26 @@ void hk_away_pen_clear2(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
 	scoreboard_away_penalty_clear(1);
 }
 
+void hk_home_major_pen_add(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
+{
+	if (!pressed)
+		return;
+	int slot = scoreboard_home_penalty_add(
+		0, scoreboard_get_default_major_penalty_duration());
+	if (slot >= 0)
+		log_penalty_event(true, 0);
+}
+
+void hk_away_major_pen_add(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
+{
+	if (!pressed)
+		return;
+	int slot = scoreboard_away_penalty_add(
+		0, scoreboard_get_default_major_penalty_duration());
+	if (slot >= 0)
+		log_penalty_event(false, 0);
+}
+
 void hk_generate_highlights(void *, obs_hotkey_id, obs_hotkey_t *,
 			     bool pressed)
 {
@@ -1715,7 +1832,7 @@ void hk_generate_highlights(void *, obs_hotkey_id, obs_hotkey_t *,
 		return;
 	if (scoreboard_clock_is_running())
 		return;
-	run_reeln_segment_command();
+	run_reeln_highlights_command();
 }
 
 void hk_home_foul_plus(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
@@ -1908,6 +2025,26 @@ void register_hotkeys()
 	g_hotkey_ids[idx++] = obs_hotkey_register_frontend(
 		"sb_away_foul2_minus", "Streamn: Away Foul2 -",
 		hk_away_foul2_minus, nullptr);
+	g_hotkey_ids[idx++] = obs_hotkey_register_frontend(
+		"sb_home_major_pen_add",
+		"Streamn: Home Major Penalty Add",
+		hk_home_major_pen_add, nullptr);
+	g_hotkey_ids[idx++] = obs_hotkey_register_frontend(
+		"sb_away_major_pen_add",
+		"Streamn: Away Major Penalty Add",
+		hk_away_major_pen_add, nullptr);
+	g_hotkey_ids[idx++] = obs_hotkey_register_frontend(
+		"sb_home_fo_plus", "Streamn: Home Faceoff +",
+		hk_home_fo_plus, nullptr);
+	g_hotkey_ids[idx++] = obs_hotkey_register_frontend(
+		"sb_home_fo_minus", "Streamn: Home Faceoff -",
+		hk_home_fo_minus, nullptr);
+	g_hotkey_ids[idx++] = obs_hotkey_register_frontend(
+		"sb_away_fo_plus", "Streamn: Away Faceoff +",
+		hk_away_fo_plus, nullptr);
+	g_hotkey_ids[idx++] = obs_hotkey_register_frontend(
+		"sb_away_fo_minus", "Streamn: Away Faceoff -",
+		hk_away_fo_minus, nullptr);
 
 	/* Register save/load callbacks to persist hotkey bindings */
 	obs_frontend_add_save_callback(save_hotkeys, nullptr);
@@ -2238,9 +2375,12 @@ bool scoreboard_dock_init(scoreboard_log_fn log_fn)
 	QPushButton *home_shot_plus = new QPushButton("+", widget);
 	home_shot_minus->setFixedWidth(28);
 	home_shot_plus->setFixedWidth(28);
+	home_shot_minus->setToolTip("Home shots on goal -1");
+	home_shot_plus->setToolTip("Home shots on goal +1");
 	g_home_shots_label = new QLabel("0", widget);
 	g_home_shots_label->setAlignment(Qt::AlignCenter);
 	g_home_shots_label->setFixedWidth(32);
+	g_home_shots_label->setToolTip("Home shots on goal");
 	shots_row->addStretch(1);
 	shots_row->addWidget(home_shot_minus);
 	shots_row->addWidget(g_home_shots_label);
@@ -2250,6 +2390,7 @@ bool scoreboard_dock_init(scoreboard_log_fn log_fn)
 	shots_label->setAlignment(Qt::AlignCenter);
 	shots_label->setStyleSheet(kMutedStyle);
 	shots_label->setFixedWidth(36);
+	shots_label->setToolTip("Shots on Goal");
 	shots_row->addSpacing(4);
 	shots_row->addWidget(shots_label);
 	shots_row->addSpacing(4);
@@ -2258,14 +2399,63 @@ bool scoreboard_dock_init(scoreboard_log_fn log_fn)
 	QPushButton *away_shot_plus = new QPushButton("+", widget);
 	away_shot_minus->setFixedWidth(28);
 	away_shot_plus->setFixedWidth(28);
+	away_shot_minus->setToolTip("Away shots on goal -1");
+	away_shot_plus->setToolTip("Away shots on goal +1");
 	g_away_shots_label = new QLabel("0", widget);
 	g_away_shots_label->setAlignment(Qt::AlignCenter);
 	g_away_shots_label->setFixedWidth(32);
+	g_away_shots_label->setToolTip("Away shots on goal");
 	shots_row->addWidget(away_shot_minus);
 	shots_row->addWidget(g_away_shots_label);
 	shots_row->addWidget(away_shot_plus);
 	shots_row->addStretch(1);
 	root->addWidget(g_shots_row_widget);
+
+	/* Faceoffs row: [-] 0 [+] FO [-] 0 [+] — wrapped for visibility toggle */
+	g_faceoffs_row_widget = new QWidget(widget);
+	QHBoxLayout *fo_row = new QHBoxLayout(g_faceoffs_row_widget);
+	fo_row->setContentsMargins(0, 0, 0, 0);
+	fo_row->setSpacing(2);
+
+	QPushButton *home_fo_minus = new QPushButton("-", widget);
+	QPushButton *home_fo_plus = new QPushButton("+", widget);
+	home_fo_minus->setFixedWidth(28);
+	home_fo_plus->setFixedWidth(28);
+	home_fo_minus->setToolTip("Home faceoff wins -1");
+	home_fo_plus->setToolTip("Home faceoff wins +1");
+	g_home_faceoffs_label = new QLabel("0", widget);
+	g_home_faceoffs_label->setAlignment(Qt::AlignCenter);
+	g_home_faceoffs_label->setFixedWidth(32);
+	g_home_faceoffs_label->setToolTip("Home faceoff wins");
+	fo_row->addStretch(1);
+	fo_row->addWidget(home_fo_minus);
+	fo_row->addWidget(g_home_faceoffs_label);
+	fo_row->addWidget(home_fo_plus);
+
+	QLabel *fo_label = new QLabel("FO", widget);
+	fo_label->setAlignment(Qt::AlignCenter);
+	fo_label->setStyleSheet(kMutedStyle);
+	fo_label->setFixedWidth(36);
+	fo_label->setToolTip("Faceoff Wins");
+	fo_row->addSpacing(4);
+	fo_row->addWidget(fo_label);
+	fo_row->addSpacing(4);
+
+	QPushButton *away_fo_minus = new QPushButton("-", widget);
+	QPushButton *away_fo_plus = new QPushButton("+", widget);
+	away_fo_minus->setFixedWidth(28);
+	away_fo_plus->setFixedWidth(28);
+	away_fo_minus->setToolTip("Away faceoff wins -1");
+	away_fo_plus->setToolTip("Away faceoff wins +1");
+	g_away_faceoffs_label = new QLabel("0", widget);
+	g_away_faceoffs_label->setAlignment(Qt::AlignCenter);
+	g_away_faceoffs_label->setFixedWidth(32);
+	g_away_faceoffs_label->setToolTip("Away faceoff wins");
+	fo_row->addWidget(away_fo_minus);
+	fo_row->addWidget(g_away_faceoffs_label);
+	fo_row->addWidget(away_fo_plus);
+	fo_row->addStretch(1);
+	root->addWidget(g_faceoffs_row_widget);
 
 	/* Fouls row: [-] 0 [+] | Label | [-] 0 [+] — wrapped for visibility toggle */
 	g_fouls_row_widget = new QWidget(widget);
@@ -2372,12 +2562,36 @@ bool scoreboard_dock_init(scoreboard_log_fn log_fn)
 	home_pen_title->setStyleSheet(kMutedStyle);
 	home_pen_title->setAlignment(Qt::AlignCenter);
 	home_pen_col->addWidget(home_pen_title);
-	g_home_pen_layout = new QVBoxLayout();
+	QWidget *home_pen_container = new QWidget(widget);
+	g_home_pen_layout = new QVBoxLayout(home_pen_container);
 	g_home_pen_layout->setContentsMargins(0, 0, 0, 0);
 	g_home_pen_layout->setSpacing(1);
-	home_pen_col->addLayout(g_home_pen_layout);
-	QPushButton *home_pen_add = new QPushButton("+ Penalty", widget);
-	home_pen_col->addWidget(home_pen_add);
+	QScrollArea *home_pen_scroll = new QScrollArea(widget);
+	home_pen_scroll->setWidget(home_pen_container);
+	home_pen_scroll->setWidgetResizable(true);
+	home_pen_scroll->setFrameShape(QFrame::NoFrame);
+	home_pen_scroll->setMaximumHeight(66);
+	home_pen_scroll->setHorizontalScrollBarPolicy(
+		Qt::ScrollBarAlwaysOff);
+	home_pen_col->addWidget(home_pen_scroll);
+	QHBoxLayout *home_pen_btns = new QHBoxLayout();
+	home_pen_btns->setContentsMargins(0, 0, 0, 0);
+	home_pen_btns->setSpacing(2);
+	QPushButton *home_pen_add = new QPushButton("+ Minor", widget);
+	QPushButton *home_major_pen_add =
+		new QPushButton("+ Major", widget);
+	home_pen_btns->addWidget(home_pen_add, 1);
+	home_pen_btns->addWidget(home_major_pen_add, 1);
+	{
+		QPalette p = home_major_pen_add->palette();
+		QColor base = p.color(QPalette::Button);
+		QColor tint = QColor::fromHslF(
+			0.08, 0.5, qBound(0.0, base.lightnessF(), 1.0));
+		home_major_pen_add->setStyleSheet(
+			"QPushButton { background-color: " + tint.name() +
+			"; }");
+	}
+	home_pen_col->addLayout(home_pen_btns);
 	pen_section->addLayout(home_pen_col, 1);
 
 	/* Away penalties column */
@@ -2388,12 +2602,36 @@ bool scoreboard_dock_init(scoreboard_log_fn log_fn)
 	away_pen_title->setStyleSheet(kMutedStyle);
 	away_pen_title->setAlignment(Qt::AlignCenter);
 	away_pen_col->addWidget(away_pen_title);
-	g_away_pen_layout = new QVBoxLayout();
+	QWidget *away_pen_container = new QWidget(widget);
+	g_away_pen_layout = new QVBoxLayout(away_pen_container);
 	g_away_pen_layout->setContentsMargins(0, 0, 0, 0);
 	g_away_pen_layout->setSpacing(1);
-	away_pen_col->addLayout(g_away_pen_layout);
-	QPushButton *away_pen_add = new QPushButton("+ Penalty", widget);
-	away_pen_col->addWidget(away_pen_add);
+	QScrollArea *away_pen_scroll = new QScrollArea(widget);
+	away_pen_scroll->setWidget(away_pen_container);
+	away_pen_scroll->setWidgetResizable(true);
+	away_pen_scroll->setFrameShape(QFrame::NoFrame);
+	away_pen_scroll->setMaximumHeight(66);
+	away_pen_scroll->setHorizontalScrollBarPolicy(
+		Qt::ScrollBarAlwaysOff);
+	away_pen_col->addWidget(away_pen_scroll);
+	QHBoxLayout *away_pen_btns = new QHBoxLayout();
+	away_pen_btns->setContentsMargins(0, 0, 0, 0);
+	away_pen_btns->setSpacing(2);
+	QPushButton *away_pen_add = new QPushButton("+ Minor", widget);
+	QPushButton *away_major_pen_add =
+		new QPushButton("+ Major", widget);
+	away_pen_btns->addWidget(away_pen_add, 1);
+	away_pen_btns->addWidget(away_major_pen_add, 1);
+	{
+		QPalette p = away_major_pen_add->palette();
+		QColor base = p.color(QPalette::Button);
+		QColor tint = QColor::fromHslF(
+			0.08, 0.5, qBound(0.0, base.lightnessF(), 1.0));
+		away_major_pen_add->setStyleSheet(
+			"QPushButton { background-color: " + tint.name() +
+			"; }");
+	}
+	away_pen_col->addLayout(away_pen_btns);
 	pen_section->addLayout(away_pen_col, 1);
 
 	pen_wrapper->addLayout(pen_section);
@@ -2498,7 +2736,6 @@ bool scoreboard_dock_init(scoreboard_log_fn log_fn)
 			return;
 		log_period_end_event();
 		scoreboard_period_advance();
-		run_reeln_segment_command();
 		update_all_labels();
 	});
 	QObject::connect(period_rew_btn, &QPushButton::clicked, []() {
@@ -2539,6 +2776,22 @@ bool scoreboard_dock_init(scoreboard_log_fn log_fn)
 	});
 	QObject::connect(away_shot_minus, &QPushButton::clicked, []() {
 		scoreboard_decrement_away_shots();
+		update_all_labels();
+	});
+	QObject::connect(home_fo_plus, &QPushButton::clicked, []() {
+		scoreboard_increment_home_faceoffs();
+		update_all_labels();
+	});
+	QObject::connect(home_fo_minus, &QPushButton::clicked, []() {
+		scoreboard_decrement_home_faceoffs();
+		update_all_labels();
+	});
+	QObject::connect(away_fo_plus, &QPushButton::clicked, []() {
+		scoreboard_increment_away_faceoffs();
+		update_all_labels();
+	});
+	QObject::connect(away_fo_minus, &QPushButton::clicked, []() {
+		scoreboard_decrement_away_faceoffs();
 		update_all_labels();
 	});
 	QObject::connect(home_foul_plus, &QPushButton::clicked, []() {
@@ -2597,10 +2850,22 @@ bool scoreboard_dock_init(scoreboard_log_fn log_fn)
 	QObject::connect(away_pen_add, &QPushButton::clicked, [widget]() {
 		open_add_penalty_dialog(widget, false);
 	});
+	QObject::connect(home_major_pen_add, &QPushButton::clicked,
+			 [widget]() {
+		open_add_penalty_dialog(
+			widget, true,
+			scoreboard_get_default_major_penalty_duration());
+	});
+	QObject::connect(away_major_pen_add, &QPushButton::clicked,
+			 [widget]() {
+		open_add_penalty_dialog(
+			widget, false,
+			scoreboard_get_default_major_penalty_duration());
+	});
 	QObject::connect(g_highlights_btn, &QPushButton::clicked, []() {
 		if (confirm_mid_period_action(g_dock_widget,
 					      "generate highlights"))
-			run_reeln_segment_command();
+			run_reeln_highlights_command();
 	});
 	QObject::connect(g_game_finished, &QCheckBox::toggled,
 			 []() { update_all_labels(); });
@@ -2742,6 +3007,9 @@ void scoreboard_dock_shutdown(void)
 	g_away_score_label = nullptr;
 	g_home_shots_label = nullptr;
 	g_away_shots_label = nullptr;
+	g_faceoffs_row_widget = nullptr;
+	g_home_faceoffs_label = nullptr;
+	g_away_faceoffs_label = nullptr;
 	g_fouls_row_widget = nullptr;
 	g_home_fouls_label = nullptr;
 	g_away_fouls_label = nullptr;

--- a/src/scoreboard-core.c
+++ b/src/scoreboard-core.c
@@ -10,17 +10,19 @@
 #define SCOREBOARD_ACTION_LOG_ENTRY_SIZE 160
 #define SCOREBOARD_DEFAULT_PERIOD_LENGTH 900
 #define SCOREBOARD_DEFAULT_PENALTY_DURATION 120
+#define SCOREBOARD_DEFAULT_MAJOR_PENALTY_DURATION 300
 #define SCOREBOARD_PENALTY_SLOTS SCOREBOARD_MAX_PENALTIES
 #define SCOREBOARD_SEGMENT_NAME_SIZE 16
 
 static const struct scoreboard_sport_preset k_sport_presets[SCOREBOARD_SPORT_COUNT] = {
-	{SCOREBOARD_SPORT_HOCKEY,     "Period",  3, 900,  4, true,  true,  SCOREBOARD_CLOCK_COUNT_DOWN, false, "",      "", true,  "Goal"},
-	{SCOREBOARD_SPORT_BASKETBALL, "Quarter", 4, 480,  1, false, false, SCOREBOARD_CLOCK_COUNT_DOWN, true,  "Fouls", "", false, "Score"},
-	{SCOREBOARD_SPORT_SOCCER,     "Half",    2, 2700, 1, false, false, SCOREBOARD_CLOCK_COUNT_UP,   true,  "YC",    "RC", true,  "Goal"},
-	{SCOREBOARD_SPORT_FOOTBALL,   "Half",    2, 1800, 1, false, false, SCOREBOARD_CLOCK_COUNT_DOWN, true,  "Flags", "", false, "Score"},
-	{SCOREBOARD_SPORT_LACROSSE,   "Quarter", 4, 720,  1, true,  true,  SCOREBOARD_CLOCK_COUNT_DOWN, false, "",      "", true,  "Goal"},
-	{SCOREBOARD_SPORT_RUGBY,      "Half",    2, 2400, 1, false, true,  SCOREBOARD_CLOCK_COUNT_UP,   false, "",      "", true,  "Try"},
-	{SCOREBOARD_SPORT_GENERIC,    "Segment", 1, 0,    0, false, false, SCOREBOARD_CLOCK_COUNT_UP,   false, "",      "", true,  "Score"},
+	/* sport, segment_name, segment_count, duration_seconds, ot_max, has_shots, has_faceoffs, has_penalties, default_direction, has_fouls, foul_label, foul_label2, log_scores, score_label, default_penalty_secs, default_major_penalty_secs */
+	{SCOREBOARD_SPORT_HOCKEY,     "Period",  3, 900,  4, true,  true,  true,  SCOREBOARD_CLOCK_COUNT_DOWN, false, "",      "", true,  "Goal",  120, 300},
+	{SCOREBOARD_SPORT_BASKETBALL, "Quarter", 4, 480,  1, false, false, false, SCOREBOARD_CLOCK_COUNT_DOWN, true,  "Fouls", "", false, "Score", 0,   0},
+	{SCOREBOARD_SPORT_SOCCER,     "Half",    2, 2700, 1, false, false, false, SCOREBOARD_CLOCK_COUNT_UP,   true,  "YC",    "RC", true,  "Goal",  0,   0},
+	{SCOREBOARD_SPORT_FOOTBALL,   "Half",    2, 1800, 1, false, false, false, SCOREBOARD_CLOCK_COUNT_DOWN, true,  "Flags", "", false, "Score", 0,   0},
+	{SCOREBOARD_SPORT_LACROSSE,   "Quarter", 4, 720,  1, true,  true,  true,  SCOREBOARD_CLOCK_COUNT_DOWN, false, "",      "", true,  "Goal",  60,  180},
+	{SCOREBOARD_SPORT_RUGBY,      "Half",    2, 2400, 1, false, false, true,  SCOREBOARD_CLOCK_COUNT_UP,   false, "",      "", true,  "Try",   120, 600},
+	{SCOREBOARD_SPORT_GENERIC,    "Segment", 1, 0,    0, false, false, false, SCOREBOARD_CLOCK_COUNT_UP,   false, "",      "", true,  "Score", 120, 300},
 };
 
 static struct {
@@ -32,6 +34,7 @@ static struct {
 	int period;
 	bool overtime_enabled;
 	int default_penalty_duration;
+	int default_major_penalty_duration;
 
 	enum scoreboard_sport sport;
 	char segment_name[SCOREBOARD_SEGMENT_NAME_SIZE];
@@ -40,6 +43,10 @@ static struct {
 	bool has_shots;
 	bool has_penalties;
 
+	char period_labels[SCOREBOARD_MAX_PERIOD_LABELS]
+			  [SCOREBOARD_PERIOD_LABEL_SIZE];
+	int period_label_count;
+
 	char home_name[SCOREBOARD_MAX_NAME];
 	char away_name[SCOREBOARD_MAX_NAME];
 
@@ -47,6 +54,9 @@ static struct {
 	int away_score;
 	int home_shots;
 	int away_shots;
+	int home_faceoffs;
+	int away_faceoffs;
+	bool has_faceoffs;
 	int home_fouls;
 	int away_fouls;
 	bool has_fouls;
@@ -116,6 +126,8 @@ static void log_message(enum scoreboard_log_level level, const char *msg)
 		g_state.log_fn(level, msg);
 }
 
+static void generate_default_period_labels(void);
+
 static bool read_text_file(const char *dir, const char *filename, char *buf,
 			   size_t buf_size)
 {
@@ -145,14 +157,15 @@ static int parse_clock_text(const char *text)
 
 static int parse_period_text(const char *text)
 {
-	int sc = g_state.segment_count;
-	if (strcmp(text, "OT") == 0)
-		return sc + 1;
-	int ot_num = 0;
-	if (sscanf(text, "OT%d", &ot_num) == 1 && ot_num >= 2)
-		return sc + ot_num;
+	/* Search labels array for an exact match */
+	for (int i = 0; i < g_state.period_label_count; i++) {
+		if (strcmp(text, g_state.period_labels[i]) == 0)
+			return i + 1;
+	}
+	/* Fallback: try parsing as a number */
 	int p = 0;
-	if (sscanf(text, "%d", &p) == 1 && p >= 1 && p <= sc)
+	if (sscanf(text, "%d", &p) == 1 && p >= 1 &&
+	    p <= g_state.period_label_count)
 		return p;
 	return -1;
 }
@@ -325,6 +338,8 @@ void scoreboard_reset_state_for_tests(void)
 	g_state.clock_tenths = SCOREBOARD_DEFAULT_PERIOD_LENGTH * 10;
 	g_state.overtime_enabled = true;
 	g_state.default_penalty_duration = SCOREBOARD_DEFAULT_PENALTY_DURATION;
+	g_state.default_major_penalty_duration =
+		SCOREBOARD_DEFAULT_MAJOR_PENALTY_DURATION;
 	safe_copy(g_state.home_name, "Home", sizeof(g_state.home_name));
 	safe_copy(g_state.away_name, "Away", sizeof(g_state.away_name));
 
@@ -335,12 +350,14 @@ void scoreboard_reset_state_for_tests(void)
 	g_state.segment_count = 3;
 	g_state.ot_max = 4;
 	g_state.has_shots = true;
+	g_state.has_faceoffs = true;
 	g_state.has_penalties = true;
 	g_state.has_fouls = false;
 	g_state.foul_label[0] = '\0';
 	g_state.foul_label2[0] = '\0';
 	g_state.log_scores = true;
 	safe_copy(g_state.score_label, "Goal", sizeof(g_state.score_label));
+	generate_default_period_labels();
 }
 
 /* ---- clock ---- */
@@ -393,7 +410,8 @@ void scoreboard_clock_tick(int elapsed_tenths)
 	}
 
 	mark_dirty();
-	scoreboard_penalty_tick(elapsed_tenths);
+	if (g_state.clock_running)
+		scoreboard_penalty_tick(elapsed_tenths);
 }
 
 int scoreboard_clock_get_tenths(void)
@@ -472,21 +490,15 @@ void scoreboard_set_period(int period)
 {
 	if (period < 1)
 		period = 1;
-	int max_period = g_state.overtime_enabled
-				 ? g_state.segment_count + g_state.ot_max
-				 : g_state.segment_count;
-	if (period > max_period)
-		period = max_period;
+	if (period > g_state.period_label_count)
+		period = g_state.period_label_count;
 	g_state.period = period;
 	mark_dirty();
 }
 
 void scoreboard_period_advance(void)
 {
-	int max_period = g_state.overtime_enabled
-				 ? g_state.segment_count + g_state.ot_max
-				 : g_state.segment_count;
-	if (g_state.period < max_period) {
+	if (g_state.period < g_state.period_label_count) {
 		g_state.period++;
 		scoreboard_clock_reset();
 		mark_dirty();
@@ -506,24 +518,117 @@ void scoreboard_format_period(char *buf, size_t size)
 {
 	if (buf == NULL || size == 0)
 		return;
-	int sc = g_state.segment_count;
-	if (g_state.period == sc + 1)
-		snprintf(buf, size, "OT");
-	else if (g_state.period > sc + 1)
-		snprintf(buf, size, "OT%d", g_state.period - sc);
-	else
-		snprintf(buf, size, "%d", g_state.period);
+	int idx = g_state.period - 1;
+	if (idx >= 0 && idx < g_state.period_label_count) {
+		snprintf(buf, size, "%s", g_state.period_labels[idx]);
+		return;
+	}
+	/* Fallback for periods beyond labels */
+	snprintf(buf, size, "%d", g_state.period);
 }
 
 void scoreboard_set_overtime_enabled(bool enabled)
 {
 	g_state.overtime_enabled = enabled;
+	generate_default_period_labels();
+	if (g_state.period > g_state.period_label_count)
+		g_state.period = g_state.period_label_count;
 	mark_dirty();
 }
 
 bool scoreboard_get_overtime_enabled(void)
 {
 	return g_state.overtime_enabled;
+}
+
+/* ---- period labels ---- */
+
+static void generate_default_period_labels(void)
+{
+	int count = 0;
+	/* Regular segments: "1", "2", "3", ... */
+	for (int i = 0; i < g_state.segment_count &&
+			count < SCOREBOARD_MAX_PERIOD_LABELS;
+	     i++) {
+		snprintf(g_state.period_labels[count],
+			 SCOREBOARD_PERIOD_LABEL_SIZE, "%d", i + 1);
+		count++;
+	}
+	/* Overtime labels: "OT", "OT2", "OT3", ... */
+	if (g_state.overtime_enabled) {
+		for (int i = 0; i < g_state.ot_max &&
+				count < SCOREBOARD_MAX_PERIOD_LABELS;
+		     i++) {
+			if (i == 0)
+				snprintf(g_state.period_labels[count],
+					 SCOREBOARD_PERIOD_LABEL_SIZE, "OT");
+			else
+				snprintf(g_state.period_labels[count],
+					 SCOREBOARD_PERIOD_LABEL_SIZE, "OT%d",
+					 i + 1);
+			count++;
+		}
+	}
+	g_state.period_label_count = count;
+}
+
+void scoreboard_set_period_labels(const char *labels)
+{
+	if (labels == NULL)
+		return;
+
+	int count = 0;
+	const char *p = labels;
+	while (*p != '\0' && count < SCOREBOARD_MAX_PERIOD_LABELS) {
+		const char *nl = strchr(p, '\n');
+		size_t len = nl ? (size_t)(nl - p) : strlen(p);
+		/* Skip empty lines */
+		if (len > 0) {
+			if (len >= SCOREBOARD_PERIOD_LABEL_SIZE)
+				len = SCOREBOARD_PERIOD_LABEL_SIZE - 1;
+			memcpy(g_state.period_labels[count], p, len);
+			g_state.period_labels[count][len] = '\0';
+			count++;
+		}
+		p = nl ? nl + 1 : p + len;
+	}
+	if (count > 0) {
+		g_state.period_label_count = count;
+		/* Clamp current period to new label count */
+		if (g_state.period > count)
+			g_state.period = count;
+		mark_dirty();
+	}
+}
+
+void scoreboard_get_period_labels(char *buf, size_t size)
+{
+	if (buf == NULL || size == 0)
+		return;
+	buf[0] = '\0';
+	size_t offset = 0;
+	for (int i = 0; i < g_state.period_label_count; i++) {
+		size_t label_len = strlen(g_state.period_labels[i]);
+		/* Need room for label + newline + null */
+		if (offset + label_len + 1 >= size)
+			break;
+		memcpy(buf + offset, g_state.period_labels[i], label_len);
+		offset += label_len;
+		buf[offset++] = '\n';
+	}
+	buf[offset] = '\0';
+}
+
+int scoreboard_get_period_label_count(void)
+{
+	return g_state.period_label_count;
+}
+
+const char *scoreboard_get_period_label(int index)
+{
+	if (index < 0 || index >= g_state.period_label_count)
+		return "";
+	return g_state.period_labels[index];
 }
 
 void scoreboard_set_default_penalty_duration(int seconds)
@@ -536,6 +641,18 @@ void scoreboard_set_default_penalty_duration(int seconds)
 int scoreboard_get_default_penalty_duration(void)
 {
 	return g_state.default_penalty_duration;
+}
+
+void scoreboard_set_default_major_penalty_duration(int seconds)
+{
+	if (seconds < 1)
+		seconds = 1;
+	g_state.default_major_penalty_duration = seconds;
+}
+
+int scoreboard_get_default_major_penalty_duration(void)
+{
+	return g_state.default_major_penalty_duration;
 }
 
 /* ---- team names ---- */
@@ -660,6 +777,61 @@ void scoreboard_decrement_away_shots(void)
 	if (g_state.away_shots > 0)
 		g_state.away_shots--;
 	mark_dirty();
+}
+
+/* ---- faceoffs ---- */
+
+int scoreboard_get_home_faceoffs(void)
+{
+	return g_state.home_faceoffs;
+}
+
+void scoreboard_set_home_faceoffs(int faceoffs)
+{
+	g_state.home_faceoffs = faceoffs < 0 ? 0 : faceoffs;
+	mark_dirty();
+}
+
+void scoreboard_increment_home_faceoffs(void)
+{
+	g_state.home_faceoffs++;
+	mark_dirty();
+}
+
+void scoreboard_decrement_home_faceoffs(void)
+{
+	if (g_state.home_faceoffs > 0)
+		g_state.home_faceoffs--;
+	mark_dirty();
+}
+
+int scoreboard_get_away_faceoffs(void)
+{
+	return g_state.away_faceoffs;
+}
+
+void scoreboard_set_away_faceoffs(int faceoffs)
+{
+	g_state.away_faceoffs = faceoffs < 0 ? 0 : faceoffs;
+	mark_dirty();
+}
+
+void scoreboard_increment_away_faceoffs(void)
+{
+	g_state.away_faceoffs++;
+	mark_dirty();
+}
+
+void scoreboard_decrement_away_faceoffs(void)
+{
+	if (g_state.away_faceoffs > 0)
+		g_state.away_faceoffs--;
+	mark_dirty();
+}
+
+bool scoreboard_get_has_faceoffs(void)
+{
+	return g_state.has_faceoffs;
 }
 
 /* ---- fouls ---- */
@@ -851,17 +1023,23 @@ int scoreboard_get_away_penalty_count(void)
 void scoreboard_penalty_tick(int elapsed_tenths)
 {
 	bool ticked = false;
+	int home_running = 0;
+	int away_running = 0;
 	for (int i = 0; i < SCOREBOARD_PENALTY_SLOTS; i++) {
-		if (g_state.home_penalties[i].active) {
+		if (g_state.home_penalties[i].active &&
+		    home_running < SCOREBOARD_MAX_RUNNING_PENALTIES) {
 			g_state.home_penalties[i].remaining_tenths -=
 				elapsed_tenths;
+			home_running++;
 			ticked = true;
 			if (g_state.home_penalties[i].remaining_tenths <= 0)
 				scoreboard_home_penalty_clear(i);
 		}
-		if (g_state.away_penalties[i].active) {
+		if (g_state.away_penalties[i].active &&
+		    away_running < SCOREBOARD_MAX_RUNNING_PENALTIES) {
 			g_state.away_penalties[i].remaining_tenths -=
 				elapsed_tenths;
+			away_running++;
 			ticked = true;
 			if (g_state.away_penalties[i].remaining_tenths <= 0)
 				scoreboard_away_penalty_clear(i);
@@ -874,17 +1052,23 @@ void scoreboard_penalty_tick(int elapsed_tenths)
 void scoreboard_penalty_adjust(int delta_tenths)
 {
 	bool adjusted = false;
+	int home_running = 0;
+	int away_running = 0;
 	for (int i = 0; i < SCOREBOARD_PENALTY_SLOTS; i++) {
-		if (g_state.home_penalties[i].active) {
+		if (g_state.home_penalties[i].active &&
+		    home_running < SCOREBOARD_MAX_RUNNING_PENALTIES) {
 			g_state.home_penalties[i].remaining_tenths +=
 				delta_tenths;
+			home_running++;
 			adjusted = true;
 			if (g_state.home_penalties[i].remaining_tenths <= 0)
 				scoreboard_home_penalty_clear(i);
 		}
-		if (g_state.away_penalties[i].active) {
+		if (g_state.away_penalties[i].active &&
+		    away_running < SCOREBOARD_MAX_RUNNING_PENALTIES) {
 			g_state.away_penalties[i].remaining_tenths +=
 				delta_tenths;
+			away_running++;
 			adjusted = true;
 			if (g_state.away_penalties[i].remaining_tenths <= 0)
 				scoreboard_away_penalty_clear(i);
@@ -939,9 +1123,13 @@ void scoreboard_format_all_penalty_numbers(bool home, char *buf, size_t size)
 	const struct scoreboard_penalty *penalties =
 		home ? g_state.home_penalties : g_state.away_penalties;
 	size_t offset = 0;
+	int running = 0;
 	for (int i = 0; i < SCOREBOARD_PENALTY_SLOTS; i++) {
 		if (!penalties[i].active)
 			continue;
+		if (running >= SCOREBOARD_MAX_RUNNING_PENALTIES)
+			break;
+		running++;
 		char line[32];
 		if (penalties[i].player_number > 0)
 			snprintf(line, sizeof(line), "#%d",
@@ -968,9 +1156,13 @@ void scoreboard_format_all_penalty_times(bool home, char *buf, size_t size)
 	const struct scoreboard_penalty *penalties =
 		home ? g_state.home_penalties : g_state.away_penalties;
 	size_t offset = 0;
+	int running = 0;
 	for (int i = 0; i < SCOREBOARD_PENALTY_SLOTS; i++) {
 		if (!penalties[i].active)
 			continue;
+		if (running >= SCOREBOARD_MAX_RUNNING_PENALTIES)
+			break;
+		running++;
 		int total_seconds = penalties[i].remaining_tenths / 10;
 		int minutes = total_seconds / 60;
 		int seconds = total_seconds % 60;
@@ -1034,6 +1226,12 @@ bool scoreboard_write_all_files(void)
 	snprintf(buf, sizeof(buf), "%d", g_state.away_shots);
 	ok = write_text_file(dir, "away_shots.txt", buf) && ok;
 
+	snprintf(buf, sizeof(buf), "%d", g_state.home_faceoffs);
+	ok = write_text_file(dir, "home_faceoffs.txt", buf) && ok;
+
+	snprintf(buf, sizeof(buf), "%d", g_state.away_faceoffs);
+	ok = write_text_file(dir, "away_faceoffs.txt", buf) && ok;
+
 	snprintf(buf, sizeof(buf), "%d", g_state.home_fouls);
 	ok = write_text_file(dir, "home_fouls.txt", buf) && ok;
 
@@ -1063,6 +1261,22 @@ bool scoreboard_write_all_files(void)
 	ok = write_text_file(dir, "sport.txt",
 			     scoreboard_sport_name(g_state.sport)) &&
 	     ok;
+
+	snprintf(buf, sizeof(buf), "%d",
+		 g_state.default_penalty_duration);
+	ok = write_text_file(dir, "default_penalty_duration.txt", buf) && ok;
+
+	snprintf(buf, sizeof(buf), "%d",
+		 g_state.default_major_penalty_duration);
+	ok = write_text_file(dir, "default_major_penalty_duration.txt", buf) &&
+	     ok;
+
+	{
+		char labels_buf[512];
+		scoreboard_get_period_labels(labels_buf, sizeof(labels_buf));
+		ok = write_text_file(dir, "period_labels.txt", labels_buf) &&
+		     ok;
+	}
 
 	g_dirty = false;
 	return ok;
@@ -1123,6 +1337,12 @@ bool scoreboard_read_all_files(void)
 	else
 		ok = false;
 
+	/* Faceoff files are optional — missing doesn't fail the read */
+	if (read_text_file(dir, "home_faceoffs.txt", buf, sizeof(buf)))
+		scoreboard_set_home_faceoffs(atoi(buf));
+	if (read_text_file(dir, "away_faceoffs.txt", buf, sizeof(buf)))
+		scoreboard_set_away_faceoffs(atoi(buf));
+
 	/* Fouls files are optional — missing doesn't fail the read */
 	if (read_text_file(dir, "home_fouls.txt", buf, sizeof(buf)))
 		scoreboard_set_home_fouls(atoi(buf));
@@ -1159,6 +1379,24 @@ bool scoreboard_read_all_files(void)
 			scoreboard_set_sport(s);
 	}
 
+	/* Penalty duration files are optional */
+	if (read_text_file(dir, "default_penalty_duration.txt", buf,
+			   sizeof(buf))) {
+		int val = atoi(buf);
+		if (val > 0)
+			g_state.default_penalty_duration = val;
+	}
+	if (read_text_file(dir, "default_major_penalty_duration.txt", buf,
+			   sizeof(buf))) {
+		int val = atoi(buf);
+		if (val > 0)
+			g_state.default_major_penalty_duration = val;
+	}
+
+	/* Period labels file is optional — overrides sport defaults */
+	if (read_text_file(dir, "period_labels.txt", buf, sizeof(buf)))
+		scoreboard_set_period_labels(buf);
+
 	g_dirty = false;
 	return ok;
 }
@@ -1189,6 +1427,8 @@ bool scoreboard_save_state(const char *path)
 	fprintf(f, "  \"away_score\": %d,\n", g_state.away_score);
 	fprintf(f, "  \"home_shots\": %d,\n", g_state.home_shots);
 	fprintf(f, "  \"away_shots\": %d,\n", g_state.away_shots);
+	fprintf(f, "  \"home_faceoffs\": %d,\n", g_state.home_faceoffs);
+	fprintf(f, "  \"away_faceoffs\": %d,\n", g_state.away_faceoffs);
 	fprintf(f, "  \"home_fouls\": %d,\n", g_state.home_fouls);
 	fprintf(f, "  \"away_fouls\": %d,\n", g_state.away_fouls);
 	fprintf(f, "  \"home_fouls2\": %d,\n", g_state.home_fouls2);
@@ -1205,14 +1445,22 @@ bool scoreboard_save_state(const char *path)
 			g_state.home_penalties[i].active ? "true" : "false");
 	}
 	for (int i = 0; i < SCOREBOARD_PENALTY_SLOTS; i++) {
-		bool last = (i == SCOREBOARD_PENALTY_SLOTS - 1);
 		fprintf(f, "  \"away_penalty%d_number\": %d,\n", i,
 			g_state.away_penalties[i].player_number);
 		fprintf(f, "  \"away_penalty%d_tenths\": %d,\n", i,
 			g_state.away_penalties[i].remaining_tenths);
-		fprintf(f, "  \"away_penalty%d_active\": %s%s\n", i,
-			g_state.away_penalties[i].active ? "true" : "false",
-			last ? "" : ",");
+		fprintf(f, "  \"away_penalty%d_active\": %s,\n", i,
+			g_state.away_penalties[i].active ? "true" : "false");
+	}
+
+	fprintf(f, "  \"period_label_count\": %d",
+		g_state.period_label_count);
+	for (int i = 0; i < g_state.period_label_count; i++) {
+		char key[32];
+		snprintf(key, sizeof(key), "period_label%d", i);
+		fprintf(f, ",\n");
+		bool last = (i == g_state.period_label_count - 1);
+		write_json_string(f, key, g_state.period_labels[i], last);
 	}
 
 	fprintf(f, "}\n");
@@ -1278,6 +1526,10 @@ bool scoreboard_load_state(const char *path)
 		parse_json_int(json, "home_shots", g_state.home_shots);
 	g_state.away_shots =
 		parse_json_int(json, "away_shots", g_state.away_shots);
+	g_state.home_faceoffs =
+		parse_json_int(json, "home_faceoffs", g_state.home_faceoffs);
+	g_state.away_faceoffs =
+		parse_json_int(json, "away_faceoffs", g_state.away_faceoffs);
 	g_state.home_fouls =
 		parse_json_int(json, "home_fouls", g_state.home_fouls);
 	g_state.away_fouls =
@@ -1310,6 +1562,23 @@ bool scoreboard_load_state(const char *path)
 			json, key, g_state.away_penalties[i].active);
 	}
 
+	{
+		int lcount = parse_json_int(json, "period_label_count", -1);
+		if (lcount > 0) {
+			if (lcount > SCOREBOARD_MAX_PERIOD_LABELS)
+				lcount = SCOREBOARD_MAX_PERIOD_LABELS;
+			g_state.period_label_count = lcount;
+			for (int i = 0; i < lcount; i++) {
+				char key[32];
+				snprintf(key, sizeof(key), "period_label%d",
+					 i);
+				parse_json_string(
+					json, key, g_state.period_labels[i],
+					SCOREBOARD_PERIOD_LABEL_SIZE);
+			}
+		}
+	}
+
 	free(json);
 	mark_dirty();
 	return true;
@@ -1323,6 +1592,8 @@ void scoreboard_new_game(void)
 	g_state.away_score = 0;
 	g_state.home_shots = 0;
 	g_state.away_shots = 0;
+	g_state.home_faceoffs = 0;
+	g_state.away_faceoffs = 0;
 	g_state.home_fouls = 0;
 	g_state.away_fouls = 0;
 	g_state.home_fouls2 = 0;
@@ -1388,6 +1659,7 @@ void scoreboard_set_sport(enum scoreboard_sport sport)
 	g_state.segment_count = p->segment_count;
 	g_state.ot_max = p->ot_max;
 	g_state.has_shots = p->has_shots;
+	g_state.has_faceoffs = p->has_faceoffs;
 	g_state.has_penalties = p->has_penalties;
 	g_state.has_fouls = p->has_fouls;
 	safe_copy(g_state.foul_label, p->foul_label,
@@ -1400,6 +1672,12 @@ void scoreboard_set_sport(enum scoreboard_sport sport)
 	if (p->duration_seconds > 0)
 		g_state.period_length = p->duration_seconds;
 	g_state.clock_direction = p->default_direction;
+	if (p->default_penalty_secs > 0)
+		g_state.default_penalty_duration = p->default_penalty_secs;
+	if (p->default_major_penalty_secs > 0)
+		g_state.default_major_penalty_duration =
+			p->default_major_penalty_secs;
+	generate_default_period_labels();
 	mark_dirty();
 }
 

--- a/tests/test-scoreboard-core-penalties.c
+++ b/tests/test-scoreboard-core-penalties.c
@@ -301,6 +301,16 @@ static void test_default_penalty_duration(void)
 	assert(scoreboard_get_default_penalty_duration() == 1);
 }
 
+static void test_default_major_penalty_duration(void)
+{
+	scoreboard_reset_state_for_tests();
+	assert(scoreboard_get_default_major_penalty_duration() == 300);
+	scoreboard_set_default_major_penalty_duration(600);
+	assert(scoreboard_get_default_major_penalty_duration() == 600);
+	scoreboard_set_default_major_penalty_duration(0);
+	assert(scoreboard_get_default_major_penalty_duration() == 1);
+}
+
 static void test_format_all_penalty_numbers(void)
 {
 	scoreboard_reset_state_for_tests();
@@ -392,7 +402,7 @@ static void test_format_all_penalty_times_null(void)
 
 static void test_format_all_penalties_order_stable(void)
 {
-	/* Add 3, clear middle, verify remaining order is stable */
+	/* Add 3, format only shows first 2 running */
 	scoreboard_reset_state_for_tests();
 	scoreboard_home_penalty_add(10, 120);
 	scoreboard_home_penalty_add(20, 60);
@@ -401,18 +411,18 @@ static void test_format_all_penalties_order_stable(void)
 	char nums[256], times[256];
 	scoreboard_format_all_penalty_numbers(true, nums, sizeof(nums));
 	scoreboard_format_all_penalty_times(true, times, sizeof(times));
-	assert(strcmp(nums, "#10\n#20\n#30") == 0);
-	assert(strcmp(times, "2:00\n1:00\n5:00") == 0);
+	assert(strcmp(nums, "#10\n#20") == 0);
+	assert(strcmp(times, "2:00\n1:00") == 0);
 
-	/* clear middle slot */
-	scoreboard_home_penalty_clear(1);
+	/* clear first slot — third promotes to running */
+	scoreboard_home_penalty_clear(0);
 	scoreboard_format_all_penalty_numbers(true, nums, sizeof(nums));
 	scoreboard_format_all_penalty_times(true, times, sizeof(times));
-	assert(strcmp(nums, "#10\n#30") == 0);
-	assert(strcmp(times, "2:00\n5:00") == 0);
+	assert(strcmp(nums, "#20\n#30") == 0);
+	assert(strcmp(times, "1:00\n5:00") == 0);
 
-	/* numbers and times stay paired */
-	scoreboard_home_penalty_clear(0);
+	/* clear second — only third remains */
+	scoreboard_home_penalty_clear(1);
 	scoreboard_format_all_penalty_numbers(true, nums, sizeof(nums));
 	scoreboard_format_all_penalty_times(true, times, sizeof(times));
 	assert(strcmp(nums, "#30") == 0);
@@ -506,6 +516,90 @@ static void test_dirty_penalty_adjust(void)
 	assert(scoreboard_is_dirty());
 }
 
+static void test_only_two_penalties_tick(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add(10, 120); /* slot 0: 1200 tenths */
+	scoreboard_home_penalty_add(20, 120); /* slot 1: 1200 tenths */
+	scoreboard_home_penalty_add(30, 120); /* slot 2: 1200 tenths (queued) */
+
+	scoreboard_penalty_tick(10);
+
+	/* First 2 should tick */
+	assert(scoreboard_get_home_penalty(0)->remaining_tenths == 1190);
+	assert(scoreboard_get_home_penalty(1)->remaining_tenths == 1190);
+	/* Third should NOT tick — it's queued */
+	assert(scoreboard_get_home_penalty(2)->remaining_tenths == 1200);
+}
+
+static void test_only_two_away_penalties_tick(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_away_penalty_add(10, 120);
+	scoreboard_away_penalty_add(20, 120);
+	scoreboard_away_penalty_add(30, 120);
+
+	scoreboard_penalty_tick(10);
+
+	assert(scoreboard_get_away_penalty(0)->remaining_tenths == 1190);
+	assert(scoreboard_get_away_penalty(1)->remaining_tenths == 1190);
+	assert(scoreboard_get_away_penalty(2)->remaining_tenths == 1200);
+}
+
+static void test_queued_penalty_starts_after_expiry(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add(10, 1);   /* slot 0: 10 tenths */
+	scoreboard_home_penalty_add(20, 120); /* slot 1: 1200 tenths */
+	scoreboard_home_penalty_add(30, 120); /* slot 2: queued */
+
+	/* Tick enough to expire slot 0 */
+	scoreboard_penalty_tick(10);
+
+	/* Slot 0 expired */
+	assert(!scoreboard_get_home_penalty(0)->active);
+	/* Slot 1 ticked */
+	assert(scoreboard_get_home_penalty(1)->remaining_tenths == 1190);
+	/* Slot 2 still queued — didn't tick this round */
+	assert(scoreboard_get_home_penalty(2)->remaining_tenths == 1200);
+
+	/* Next tick: slot 2 is now one of the first 2 active, so it ticks */
+	scoreboard_penalty_tick(10);
+	assert(scoreboard_get_home_penalty(1)->remaining_tenths == 1180);
+	assert(scoreboard_get_home_penalty(2)->remaining_tenths == 1190);
+}
+
+static void test_penalty_adjust_only_running(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add(10, 120); /* slot 0: 1200 tenths */
+	scoreboard_home_penalty_add(20, 120); /* slot 1: 1200 tenths */
+	scoreboard_home_penalty_add(30, 120); /* slot 2: queued */
+
+	scoreboard_penalty_adjust(-100);
+
+	/* First 2 adjusted */
+	assert(scoreboard_get_home_penalty(0)->remaining_tenths == 1100);
+	assert(scoreboard_get_home_penalty(1)->remaining_tenths == 1100);
+	/* Queued penalty NOT adjusted */
+	assert(scoreboard_get_home_penalty(2)->remaining_tenths == 1200);
+}
+
+static void test_format_only_running_penalties(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add(10, 120);
+	scoreboard_home_penalty_add(20, 60);
+	scoreboard_home_penalty_add(30, 300);
+
+	char nums[256], times[256];
+	/* Format should only show first 2 running penalties */
+	scoreboard_format_all_penalty_numbers(true, nums, sizeof(nums));
+	scoreboard_format_all_penalty_times(true, times, sizeof(times));
+	assert(strcmp(nums, "#10\n#20") == 0);
+	assert(strcmp(times, "2:00\n1:00") == 0);
+}
+
 int main(void)
 {
 	test_home_penalty_add();
@@ -539,6 +633,7 @@ int main(void)
 	test_away_penalty_count();
 	test_format_penalty_number_zero();
 	test_default_penalty_duration();
+	test_default_major_penalty_duration();
 	test_format_all_penalty_numbers();
 	test_format_all_penalty_numbers_away();
 	test_format_all_penalty_numbers_null();
@@ -555,6 +650,11 @@ int main(void)
 	test_dirty_penalty_tick_active();
 	test_dirty_penalty_tick_no_active();
 	test_dirty_penalty_adjust();
+	test_only_two_penalties_tick();
+	test_only_two_away_penalties_tick();
+	test_queued_penalty_starts_after_expiry();
+	test_penalty_adjust_only_running();
+	test_format_only_running_penalties();
 
 	printf("All scoreboard-core penalty tests passed.\n");
 	return 0;

--- a/tests/test-scoreboard-core-persistence.c
+++ b/tests/test-scoreboard-core-persistence.c
@@ -833,6 +833,8 @@ static void test_write_read_round_trip(void)
 	scoreboard_clock_set_tenths(5100); /* 8:30 */
 	scoreboard_home_penalty_add(12, 120);
 	scoreboard_away_penalty_add(22, 60);
+	scoreboard_set_default_penalty_duration(90);
+	scoreboard_set_default_major_penalty_duration(450);
 
 	bool ok = scoreboard_write_all_files();
 	assert(ok);
@@ -860,6 +862,8 @@ static void test_write_read_round_trip(void)
 	assert(scoreboard_get_home_penalty(0)->player_number == 12);
 	assert(scoreboard_get_away_penalty_count() == 1);
 	assert(scoreboard_get_away_penalty(0)->player_number == 22);
+	assert(scoreboard_get_default_penalty_duration() == 90);
+	assert(scoreboard_get_default_major_penalty_duration() == 450);
 
 	cleanup_tmp_dir();
 }
@@ -1021,6 +1025,187 @@ static void test_dirty_write_no_dir_dirty(void)
 	assert(!scoreboard_write_all_files());
 }
 
+static void test_faceoffs_write_read_files(void)
+{
+	scoreboard_reset_state_for_tests();
+	setup_tmp_dir();
+	scoreboard_set_output_directory(g_tmp_dir);
+
+	scoreboard_set_home_faceoffs(15);
+	scoreboard_set_away_faceoffs(12);
+	scoreboard_mark_dirty();
+	assert(scoreboard_write_all_files());
+
+	char path[512];
+	char *content;
+
+	snprintf(path, sizeof(path), "%s/home_faceoffs.txt", g_tmp_dir);
+	content = read_file_content(path);
+	assert(content != NULL);
+	assert(strcmp(content, "15") == 0);
+	free(content);
+
+	snprintf(path, sizeof(path), "%s/away_faceoffs.txt", g_tmp_dir);
+	content = read_file_content(path);
+	assert(content != NULL);
+	assert(strcmp(content, "12") == 0);
+	free(content);
+
+	/* Reset then read back */
+	scoreboard_set_home_faceoffs(0);
+	scoreboard_set_away_faceoffs(0);
+	assert(scoreboard_read_all_files());
+	assert(scoreboard_get_home_faceoffs() == 15);
+	assert(scoreboard_get_away_faceoffs() == 12);
+
+	cleanup_tmp_dir();
+}
+
+static void test_faceoffs_save_load_state(void)
+{
+	scoreboard_reset_state_for_tests();
+	setup_tmp_dir();
+
+	scoreboard_set_home_faceoffs(20);
+	scoreboard_set_away_faceoffs(18);
+
+	char save_path[512];
+	snprintf(save_path, sizeof(save_path), "%s/state_fo.json", g_tmp_dir);
+
+	assert(scoreboard_save_state(save_path));
+
+	/* Reset then load */
+	scoreboard_reset_state_for_tests();
+	assert(scoreboard_get_home_faceoffs() == 0);
+	assert(scoreboard_get_away_faceoffs() == 0);
+
+	assert(scoreboard_load_state(save_path));
+	assert(scoreboard_get_home_faceoffs() == 20);
+	assert(scoreboard_get_away_faceoffs() == 18);
+
+	cleanup_tmp_dir();
+}
+
+static void test_period_labels_write_read(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_period_labels("Q1\nQ2\nQ3\nQ4\nOT\n");
+
+	setup_tmp_dir();
+	scoreboard_set_output_directory(g_tmp_dir);
+	scoreboard_mark_dirty();
+	assert(scoreboard_write_all_files());
+
+	/* Verify period_labels.txt content */
+	char path[512];
+	snprintf(path, sizeof(path), "%s/period_labels.txt", g_tmp_dir);
+	char *content = read_file_content(path);
+	assert(content != NULL);
+	assert(strcmp(content, "Q1\nQ2\nQ3\nQ4\nOT\n") == 0);
+	free(content);
+
+	/* Reset to defaults, read back */
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_output_directory(g_tmp_dir);
+	assert(scoreboard_read_all_files());
+	assert(scoreboard_get_period_label_count() == 5);
+	assert(strcmp(scoreboard_get_period_label(0), "Q1") == 0);
+	assert(strcmp(scoreboard_get_period_label(4), "OT") == 0);
+
+	cleanup_tmp_dir();
+}
+
+static void test_period_labels_save_load_zero_labels(void)
+{
+	/* Craft a JSON with period_label_count: 0 */
+	scoreboard_reset_state_for_tests();
+
+	char tmpfile[256];
+#ifdef _WIN32
+	snprintf(tmpfile, sizeof(tmpfile), "%s\\sb_test_%d.json",
+		 getenv("TEMP") ? getenv("TEMP") : ".", (int)getpid());
+#else
+	snprintf(tmpfile, sizeof(tmpfile), "/tmp/sb_test_%d.json",
+		 (int)getpid());
+#endif
+
+	/* Save state first to get a valid base JSON */
+	assert(scoreboard_save_state(tmpfile));
+
+	/* Load it back — labels should survive from save */
+	scoreboard_reset_state_for_tests();
+	assert(scoreboard_load_state(tmpfile));
+	assert(scoreboard_get_period_label_count() == 7);
+
+	remove(tmpfile);
+}
+
+static void test_period_labels_load_exceeds_max(void)
+{
+	scoreboard_reset_state_for_tests();
+
+	char tmpfile[256];
+#ifdef _WIN32
+	snprintf(tmpfile, sizeof(tmpfile), "%s\\sb_test2_%d.json",
+		 getenv("TEMP") ? getenv("TEMP") : ".", (int)getpid());
+#else
+	snprintf(tmpfile, sizeof(tmpfile), "/tmp/sb_test2_%d.json",
+		 (int)getpid());
+#endif
+
+	/* Write a JSON with period_label_count exceeding max */
+	FILE *f = fopen(tmpfile, "w");
+	assert(f != NULL);
+	fprintf(f, "{\n");
+	fprintf(f, "  \"period_label_count\": 20,\n");
+	for (int i = 0; i < 20; i++) {
+		fprintf(f, "  \"period_label%d\": \"L%d\"%s\n", i, i,
+			i < 19 ? "," : "");
+	}
+	fprintf(f, "}\n");
+	fclose(f);
+
+	assert(scoreboard_load_state(tmpfile));
+	assert(scoreboard_get_period_label_count() ==
+	       SCOREBOARD_MAX_PERIOD_LABELS);
+
+	remove(tmpfile);
+}
+
+static void test_period_beyond_labels_format(void)
+{
+	/* Craft a JSON where period > period_label_count to exercise
+	   the fallback branch in format_period */
+	scoreboard_reset_state_for_tests();
+
+	char tmpfile[256];
+#ifdef _WIN32
+	snprintf(tmpfile, sizeof(tmpfile), "%s\\sb_test3_%d.json",
+		 getenv("TEMP") ? getenv("TEMP") : ".", (int)getpid());
+#else
+	snprintf(tmpfile, sizeof(tmpfile), "/tmp/sb_test3_%d.json",
+		 (int)getpid());
+#endif
+
+	FILE *f = fopen(tmpfile, "w");
+	assert(f != NULL);
+	fprintf(f, "{\n");
+	fprintf(f, "  \"period\": 5,\n");
+	fprintf(f, "  \"period_label_count\": 2,\n");
+	fprintf(f, "  \"period_label0\": \"A\",\n");
+	fprintf(f, "  \"period_label1\": \"B\"\n");
+	fprintf(f, "}\n");
+	fclose(f);
+
+	assert(scoreboard_load_state(tmpfile));
+	/* period was loaded as 5 but labels only go to 2 — exercise fallback */
+	char buf[16];
+	scoreboard_format_period(buf, sizeof(buf));
+	assert(strcmp(buf, "5") == 0);
+
+	remove(tmpfile);
+}
+
 int main(void)
 {
 	test_write_all_files();
@@ -1066,6 +1251,12 @@ int main(void)
 	test_dirty_load_state_sets();
 	test_dirty_write_no_dir_not_dirty();
 	test_dirty_write_no_dir_dirty();
+	test_faceoffs_write_read_files();
+	test_faceoffs_save_load_state();
+	test_period_labels_write_read();
+	test_period_labels_save_load_zero_labels();
+	test_period_labels_load_exceeds_max();
+	test_period_beyond_labels_format();
 
 	printf("All scoreboard-core persistence tests passed.\n");
 	return 0;

--- a/tests/test-scoreboard-core-scoring.c
+++ b/tests/test-scoreboard-core-scoring.c
@@ -292,6 +292,112 @@ static void test_dirty_away_name(void)
 	assert(scoreboard_is_dirty());
 }
 
+static void test_home_faceoffs(void)
+{
+	scoreboard_reset_state_for_tests();
+	assert(scoreboard_get_home_faceoffs() == 0);
+	scoreboard_increment_home_faceoffs();
+	assert(scoreboard_get_home_faceoffs() == 1);
+	scoreboard_increment_home_faceoffs();
+	assert(scoreboard_get_home_faceoffs() == 2);
+	scoreboard_decrement_home_faceoffs();
+	assert(scoreboard_get_home_faceoffs() == 1);
+}
+
+static void test_home_faceoffs_floor(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_decrement_home_faceoffs();
+	assert(scoreboard_get_home_faceoffs() == 0);
+}
+
+static void test_home_faceoffs_set(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_home_faceoffs(10);
+	assert(scoreboard_get_home_faceoffs() == 10);
+	scoreboard_set_home_faceoffs(-3);
+	assert(scoreboard_get_home_faceoffs() == 0);
+}
+
+static void test_away_faceoffs(void)
+{
+	scoreboard_reset_state_for_tests();
+	assert(scoreboard_get_away_faceoffs() == 0);
+	scoreboard_increment_away_faceoffs();
+	assert(scoreboard_get_away_faceoffs() == 1);
+	scoreboard_decrement_away_faceoffs();
+	assert(scoreboard_get_away_faceoffs() == 0);
+}
+
+static void test_away_faceoffs_floor(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_decrement_away_faceoffs();
+	assert(scoreboard_get_away_faceoffs() == 0);
+}
+
+static void test_away_faceoffs_set(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_away_faceoffs(7);
+	assert(scoreboard_get_away_faceoffs() == 7);
+	scoreboard_set_away_faceoffs(-1);
+	assert(scoreboard_get_away_faceoffs() == 0);
+}
+
+static void test_new_game_resets_faceoffs(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_home_faceoffs(15);
+	scoreboard_set_away_faceoffs(12);
+	scoreboard_new_game();
+	assert(scoreboard_get_home_faceoffs() == 0);
+	assert(scoreboard_get_away_faceoffs() == 0);
+}
+
+static void test_dirty_home_faceoffs(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_home_faceoffs(5);
+	assert(scoreboard_is_dirty());
+}
+
+static void test_dirty_increment_home_faceoffs(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_increment_home_faceoffs();
+	assert(scoreboard_is_dirty());
+}
+
+static void test_dirty_decrement_home_faceoffs(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_decrement_home_faceoffs();
+	assert(scoreboard_is_dirty());
+}
+
+static void test_dirty_away_faceoffs(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_away_faceoffs(5);
+	assert(scoreboard_is_dirty());
+}
+
+static void test_dirty_increment_away_faceoffs(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_increment_away_faceoffs();
+	assert(scoreboard_is_dirty());
+}
+
+static void test_dirty_decrement_away_faceoffs(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_decrement_away_faceoffs();
+	assert(scoreboard_is_dirty());
+}
+
 static void test_dirty_new_game(void)
 {
 	scoreboard_reset_state_for_tests();
@@ -333,6 +439,19 @@ int main(void)
 	test_dirty_decrement_away_shots();
 	test_dirty_home_name();
 	test_dirty_away_name();
+	test_home_faceoffs();
+	test_home_faceoffs_floor();
+	test_home_faceoffs_set();
+	test_away_faceoffs();
+	test_away_faceoffs_floor();
+	test_away_faceoffs_set();
+	test_new_game_resets_faceoffs();
+	test_dirty_home_faceoffs();
+	test_dirty_increment_home_faceoffs();
+	test_dirty_decrement_home_faceoffs();
+	test_dirty_away_faceoffs();
+	test_dirty_increment_away_faceoffs();
+	test_dirty_decrement_away_faceoffs();
 	test_dirty_new_game();
 
 	printf("All scoreboard-core scoring tests passed.\n");

--- a/tests/test-scoreboard-core-sport.c
+++ b/tests/test-scoreboard-core-sport.c
@@ -75,6 +75,10 @@ static void test_set_sport_hockey(void)
 	assert(p->has_shots == true);
 	assert(p->has_penalties == true);
 	assert(p->default_direction == SCOREBOARD_CLOCK_COUNT_DOWN);
+	assert(p->default_penalty_secs == 120);
+	assert(p->default_major_penalty_secs == 300);
+	assert(scoreboard_get_default_penalty_duration() == 120);
+	assert(scoreboard_get_default_major_penalty_duration() == 300);
 }
 
 static void test_set_sport_basketball(void)
@@ -123,6 +127,8 @@ static void test_set_sport_lacrosse(void)
 	assert(scoreboard_get_has_penalties() == true);
 	assert(scoreboard_get_period_length() == 720);
 	assert(scoreboard_get_clock_direction() == SCOREBOARD_CLOCK_COUNT_DOWN);
+	assert(scoreboard_get_default_penalty_duration() == 60);
+	assert(scoreboard_get_default_major_penalty_duration() == 180);
 }
 
 static void test_set_sport_generic(void)
@@ -651,6 +657,112 @@ static void test_score_label_per_sport(void)
 	assert(strcmp(scoreboard_get_score_label(), "Score") == 0);
 }
 
+static void test_has_faceoffs_per_sport(void)
+{
+	scoreboard_reset_state_for_tests();
+
+	scoreboard_set_sport(SCOREBOARD_SPORT_HOCKEY);
+	assert(scoreboard_get_has_faceoffs() == true);
+
+	scoreboard_set_sport(SCOREBOARD_SPORT_BASKETBALL);
+	assert(scoreboard_get_has_faceoffs() == false);
+
+	scoreboard_set_sport(SCOREBOARD_SPORT_SOCCER);
+	assert(scoreboard_get_has_faceoffs() == false);
+
+	scoreboard_set_sport(SCOREBOARD_SPORT_FOOTBALL);
+	assert(scoreboard_get_has_faceoffs() == false);
+
+	scoreboard_set_sport(SCOREBOARD_SPORT_LACROSSE);
+	assert(scoreboard_get_has_faceoffs() == true);
+
+	scoreboard_set_sport(SCOREBOARD_SPORT_RUGBY);
+	assert(scoreboard_get_has_faceoffs() == false);
+
+	scoreboard_set_sport(SCOREBOARD_SPORT_GENERIC);
+	assert(scoreboard_get_has_faceoffs() == false);
+}
+
+static void test_faceoffs_reset_by_new_game(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_home_faceoffs(15);
+	scoreboard_set_away_faceoffs(12);
+	scoreboard_new_game();
+	assert(scoreboard_get_home_faceoffs() == 0);
+	assert(scoreboard_get_away_faceoffs() == 0);
+}
+
+static void test_default_labels_per_sport(void)
+{
+	/* Hockey: 1,2,3,OT,OT2,OT3,OT4 */
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_sport(SCOREBOARD_SPORT_HOCKEY);
+	assert(scoreboard_get_period_label_count() == 7);
+	assert(strcmp(scoreboard_get_period_label(3), "OT") == 0);
+
+	/* Basketball: 1,2,3,4,OT */
+	scoreboard_set_sport(SCOREBOARD_SPORT_BASKETBALL);
+	assert(scoreboard_get_period_label_count() == 5);
+	assert(strcmp(scoreboard_get_period_label(3), "4") == 0);
+	assert(strcmp(scoreboard_get_period_label(4), "OT") == 0);
+
+	/* Soccer: 1,2,OT */
+	scoreboard_set_sport(SCOREBOARD_SPORT_SOCCER);
+	assert(scoreboard_get_period_label_count() == 3);
+	assert(strcmp(scoreboard_get_period_label(0), "1") == 0);
+	assert(strcmp(scoreboard_get_period_label(2), "OT") == 0);
+
+	/* Generic: 1 (1 segment, no OT) */
+	scoreboard_set_sport(SCOREBOARD_SPORT_GENERIC);
+	assert(scoreboard_get_period_label_count() == 1);
+	assert(strcmp(scoreboard_get_period_label(0), "1") == 0);
+}
+
+static void test_period_labels_write_read_files(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_period_labels("1\n2\n3\n4\n5\nOT\n2OT\n");
+
+	char tmpdir[256];
+	make_tmp_dir(tmpdir, sizeof(tmpdir));
+	scoreboard_set_output_directory(tmpdir);
+	scoreboard_mark_dirty();
+	assert(scoreboard_write_all_files());
+
+	/* Reset labels, then read back */
+	scoreboard_set_period_labels("A\nB\n");
+	assert(scoreboard_get_period_label_count() == 2);
+
+	assert(scoreboard_read_all_files());
+	assert(scoreboard_get_period_label_count() == 7);
+	assert(strcmp(scoreboard_get_period_label(5), "OT") == 0);
+	assert(strcmp(scoreboard_get_period_label(6), "2OT") == 0);
+
+	cleanup_dir(tmpdir);
+}
+
+static void test_period_labels_save_load_state(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_period_labels("Q1\nQ2\nQ3\nQ4\nOT\n");
+
+	char tmpfile[256];
+	make_tmp_file(tmpfile, sizeof(tmpfile));
+	assert(scoreboard_save_state(tmpfile));
+
+	/* Reset, then load */
+	scoreboard_reset_state_for_tests();
+	assert(scoreboard_get_period_label_count() == 7);
+
+	assert(scoreboard_load_state(tmpfile));
+	assert(scoreboard_get_period_label_count() == 5);
+	assert(strcmp(scoreboard_get_period_label(0), "Q1") == 0);
+	assert(strcmp(scoreboard_get_period_label(4), "OT") == 0);
+
+	remove(tmpfile);
+}
+
 int main(void)
 {
 	test_default_sport_is_hockey();
@@ -691,6 +803,11 @@ int main(void)
 	test_fouls2_reset_by_new_game();
 	test_log_scores_per_sport();
 	test_score_label_per_sport();
+	test_has_faceoffs_per_sport();
+	test_faceoffs_reset_by_new_game();
+	test_default_labels_per_sport();
+	test_period_labels_write_read_files();
+	test_period_labels_save_load_state();
 
 	printf("All scoreboard-core sport tests passed.\n");
 	return 0;

--- a/tests/test-scoreboard-core.c
+++ b/tests/test-scoreboard-core.c
@@ -435,6 +435,40 @@ static void test_penalty_adjust_positive_delta(void)
 	assert(scoreboard_get_home_penalty(1)->remaining_tenths == 0);
 }
 
+static void test_penalties_stop_when_clock_stops(void)
+{
+	scoreboard_reset_state_for_tests();
+	/* Set clock to 1 second (10 tenths) */
+	scoreboard_clock_set_tenths(10);
+	scoreboard_home_penalty_add(12, 120); /* 1200 tenths */
+
+	scoreboard_clock_start();
+	/* Tick 10 tenths — clock reaches 0:00 and auto-stops */
+	scoreboard_clock_tick(10);
+
+	assert(scoreboard_clock_get_tenths() == 0);
+	assert(!scoreboard_clock_is_running());
+	/* Penalty should NOT have been decremented on the stopping tick */
+	assert(scoreboard_get_home_penalty(0)->remaining_tenths == 1200);
+}
+
+static void test_penalties_tick_while_clock_runs(void)
+{
+	scoreboard_reset_state_for_tests();
+	/* Set clock to 2 seconds (20 tenths) */
+	scoreboard_clock_set_tenths(20);
+	scoreboard_home_penalty_add(12, 120); /* 1200 tenths */
+
+	scoreboard_clock_start();
+	/* Tick 10 tenths — clock still has 10 left, stays running */
+	scoreboard_clock_tick(10);
+
+	assert(scoreboard_clock_get_tenths() == 10);
+	assert(scoreboard_clock_is_running());
+	/* Penalty SHOULD have ticked */
+	assert(scoreboard_get_home_penalty(0)->remaining_tenths == 1190);
+}
+
 static void test_overtime_enabled(void)
 {
 	scoreboard_reset_state_for_tests();
@@ -564,6 +598,179 @@ static void test_dirty_mark_dirty(void)
 	assert(scoreboard_is_dirty());
 }
 
+/* ---- period label tests ---- */
+
+static void test_default_period_labels_hockey(void)
+{
+	scoreboard_reset_state_for_tests();
+	assert(scoreboard_get_period_label_count() == 7);
+	assert(strcmp(scoreboard_get_period_label(0), "1") == 0);
+	assert(strcmp(scoreboard_get_period_label(1), "2") == 0);
+	assert(strcmp(scoreboard_get_period_label(2), "3") == 0);
+	assert(strcmp(scoreboard_get_period_label(3), "OT") == 0);
+	assert(strcmp(scoreboard_get_period_label(4), "OT2") == 0);
+	assert(strcmp(scoreboard_get_period_label(5), "OT3") == 0);
+	assert(strcmp(scoreboard_get_period_label(6), "OT4") == 0);
+}
+
+static void test_period_labels_no_ot(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_overtime_enabled(false);
+	assert(scoreboard_get_period_label_count() == 3);
+	assert(strcmp(scoreboard_get_period_label(0), "1") == 0);
+	assert(strcmp(scoreboard_get_period_label(1), "2") == 0);
+	assert(strcmp(scoreboard_get_period_label(2), "3") == 0);
+}
+
+static void test_set_custom_period_labels(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_period_labels("1\n2\n3\n4\n5\nOT\n2OT\n");
+	assert(scoreboard_get_period_label_count() == 7);
+	assert(strcmp(scoreboard_get_period_label(0), "1") == 0);
+	assert(strcmp(scoreboard_get_period_label(4), "5") == 0);
+	assert(strcmp(scoreboard_get_period_label(5), "OT") == 0);
+	assert(strcmp(scoreboard_get_period_label(6), "2OT") == 0);
+
+	/* format_period uses custom labels */
+	char buf[16];
+	scoreboard_set_period(6);
+	scoreboard_format_period(buf, sizeof(buf));
+	assert(strcmp(buf, "OT") == 0);
+
+	scoreboard_set_period(7);
+	scoreboard_format_period(buf, sizeof(buf));
+	assert(strcmp(buf, "2OT") == 0);
+}
+
+static void test_period_labels_clamp_period(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_period(5);
+	/* Set labels with fewer entries — period should clamp */
+	scoreboard_set_period_labels("1\n2\n3\n");
+	assert(scoreboard_get_period_label_count() == 3);
+	assert(scoreboard_get_period() == 3);
+}
+
+static void test_period_labels_skip_empty_lines(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_period_labels("1\n\n2\n\n3\n");
+	assert(scoreboard_get_period_label_count() == 3);
+	assert(strcmp(scoreboard_get_period_label(0), "1") == 0);
+	assert(strcmp(scoreboard_get_period_label(1), "2") == 0);
+	assert(strcmp(scoreboard_get_period_label(2), "3") == 0);
+}
+
+static void test_period_labels_null_ignored(void)
+{
+	scoreboard_reset_state_for_tests();
+	int orig = scoreboard_get_period_label_count();
+	scoreboard_set_period_labels(NULL);
+	assert(scoreboard_get_period_label_count() == orig);
+}
+
+static void test_period_labels_empty_string_ignored(void)
+{
+	scoreboard_reset_state_for_tests();
+	int orig = scoreboard_get_period_label_count();
+	scoreboard_set_period_labels("");
+	assert(scoreboard_get_period_label_count() == orig);
+}
+
+static void test_get_period_labels_roundtrip(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_period_labels("A\nB\nC\n");
+	char buf[256];
+	scoreboard_get_period_labels(buf, sizeof(buf));
+	assert(strcmp(buf, "A\nB\nC\n") == 0);
+}
+
+static void test_get_period_labels_null(void)
+{
+	scoreboard_get_period_labels(NULL, 0);
+	char buf[2];
+	scoreboard_get_period_labels(buf, 0);
+}
+
+static void test_get_period_label_out_of_range(void)
+{
+	scoreboard_reset_state_for_tests();
+	assert(strcmp(scoreboard_get_period_label(-1), "") == 0);
+	assert(strcmp(scoreboard_get_period_label(100), "") == 0);
+}
+
+static void test_period_format_fallback_beyond_labels(void)
+{
+	scoreboard_reset_state_for_tests();
+	/* Force period beyond label count via direct state manipulation */
+	scoreboard_set_period_labels("X\nY\n");
+	/* period_label_count is 2, period was clamped to 2 */
+	char buf[16];
+	scoreboard_set_period(2);
+	scoreboard_format_period(buf, sizeof(buf));
+	assert(strcmp(buf, "Y") == 0);
+}
+
+static void test_overtime_enabled_regenerates_labels(void)
+{
+	scoreboard_reset_state_for_tests();
+	assert(scoreboard_get_period_label_count() == 7);
+	scoreboard_set_overtime_enabled(false);
+	assert(scoreboard_get_period_label_count() == 3);
+	scoreboard_set_overtime_enabled(true);
+	assert(scoreboard_get_period_label_count() == 7);
+}
+
+static void test_set_period_labels_marks_dirty(void)
+{
+	scoreboard_reset_state_for_tests();
+	assert(!scoreboard_is_dirty());
+	scoreboard_set_period_labels("1\n2\n");
+	assert(scoreboard_is_dirty());
+}
+
+static void test_period_labels_long_label_truncated(void)
+{
+	scoreboard_reset_state_for_tests();
+	/* SCOREBOARD_PERIOD_LABEL_SIZE is 16, so a 20-char label gets truncated */
+	scoreboard_set_period_labels("ABCDEFGHIJKLMNOPQRST\n");
+	assert(scoreboard_get_period_label_count() == 1);
+	assert(strlen(scoreboard_get_period_label(0)) == 15);
+}
+
+static void test_get_period_labels_small_buffer(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_set_period_labels("Alpha\nBeta\nGamma\n");
+	/* Buffer too small to hold all labels — stops early */
+	char buf[8];
+	scoreboard_get_period_labels(buf, sizeof(buf));
+	/* Should have "Alpha\n" (6 chars) and stop before Beta */
+	assert(strcmp(buf, "Alpha\n") == 0);
+}
+
+static void test_period_format_beyond_labels(void)
+{
+	scoreboard_reset_state_for_tests();
+	/* Manually force period beyond label range by setting labels after
+	   setting period. We need a trick: set many labels first, set period
+	   high, then reduce labels. But set_period_labels clamps... so instead
+	   test the fallback path by checking format works at boundary. */
+	/* The fallback prints the raw number. We can't reach it via the public
+	   API since set_period clamps, but we can test via a save/load
+	   with a hand-crafted JSON that has period > label count. For now,
+	   we verify the label-based path works at max index. */
+	scoreboard_set_period_labels("X\n");
+	scoreboard_set_period(1);
+	char buf[16];
+	scoreboard_format_period(buf, sizeof(buf));
+	assert(strcmp(buf, "X") == 0);
+}
+
 int main(void)
 {
 	test_description();
@@ -600,6 +807,8 @@ int main(void)
 	test_penalty_adjust_both_teams();
 	test_penalty_clear_after_adjust();
 	test_penalty_adjust_positive_delta();
+	test_penalties_stop_when_clock_stops();
+	test_penalties_tick_while_clock_runs();
 	test_overtime_enabled();
 	test_dirty_reset_clears();
 	test_dirty_clock_start();
@@ -617,6 +826,22 @@ int main(void)
 	test_dirty_period_rewind();
 	test_dirty_set_overtime_enabled();
 	test_dirty_mark_dirty();
+	test_default_period_labels_hockey();
+	test_period_labels_no_ot();
+	test_set_custom_period_labels();
+	test_period_labels_clamp_period();
+	test_period_labels_skip_empty_lines();
+	test_period_labels_null_ignored();
+	test_period_labels_empty_string_ignored();
+	test_get_period_labels_roundtrip();
+	test_get_period_labels_null();
+	test_get_period_label_out_of_range();
+	test_period_format_fallback_beyond_labels();
+	test_overtime_enabled_regenerates_labels();
+	test_set_period_labels_marks_dirty();
+	test_period_labels_long_label_truncated();
+	test_get_period_labels_small_buffer();
+	test_period_format_beyond_labels();
 
 	printf("All scoreboard-core clock/period tests passed.\n");
 	return 0;


### PR DESCRIPTION
## Summary

- **Configurable period labels** — sport-specific defaults (e.g. hockey: 1, 2, 3, OT, OT2, OT3, OT4) with external file override via `period_labels.txt`. "Edit..." button in Game Settings opens the file in the user's default text editor. File watcher applies changes live.
- **Faceoff wins counter** — home/away tracking for hockey and lacrosse, displayed below SOG in dock UI. Includes +/- buttons, 4 OBS hotkeys, `home_faceoffs.txt`/`away_faceoffs.txt` output files, JSON persistence, and tooltips on all stat rows.
- **Penalty queue** — only 2 penalties per team tick simultaneously (`SCOREBOARD_MAX_RUNNING_PENALTIES`), matching hockey rules. Additional penalties queue and auto-start when earlier ones expire. Dock UI shows queued penalties with "(queued)" suffix. Text file output shows only running penalties.
- **Fix: Start/Stop button state** — button now resets to green "Start" when clock auto-stops at 0:00 (previously stayed red "Stop").
- **Fix: Penalty-clock coupling** — penalty timers freeze when period clock reaches 0:00 (previously kept ticking after auto-stop).

## Test plan

- [ ] `make dev` — all 7 test binaries pass
- [ ] `make coverage` — 100% line coverage on scoreboard-core.c
- [ ] `make install && make run` — verify in OBS:
  - [ ] Hockey: FO row visible below SOG, faceoff +/- works, hotkeys work
  - [ ] Basketball: FO row hidden
  - [ ] Add 3 penalties → only 2 tick, 3rd shows "(queued)" in dock
  - [ ] Let one expire → 3rd auto-starts
  - [ ] Clock reaches 0:00 → button resets to green, penalties freeze
  - [ ] Game Settings → "Edit..." opens period_labels.txt
  - [ ] Edit labels externally → dock updates live
- [ ] Reeln plugin tests: `uv run pytest tests/` — 81 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)