### PR TITLE
feat: Compound penalties, slot consolidation, edit, and hotkey dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to Streamn Scoreboard will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-08
+
+### Added
+- Compound penalty support (2+2, 2+5, 2+10) — two-phase penalties where phase 2 auto-starts when phase 1 expires, matching hockey rules for double-minor and major infractions
+- Phase 2 toggle buttons (+2, +5, +10) in the add-penalty dialog — select one for compound, deselect all for regular; only shown for sports with major penalties (hockey, lacrosse, rugby)
+- Compound indicator `(+M:SS)` shown in the dock UI for penalties still in phase 1
+- Edit button (✏) on each active penalty row — click to change remaining time
+- 4 new OBS hotkeys: Home/Away Penalty Edit 1/2 — opens edit dialog for the first or second running penalty
+- 4 new OBS hotkeys: Home/Away 2+2 Penalty Add, Home/Away 2+5 Penalty Add — open add-penalty dialog with compound phase pre-selected
+- `scoreboard_penalty_compact()` API — consolidates penalties to lowest slots after any clear or expiry
+- `scoreboard_home_penalty_set_time()` / `scoreboard_away_penalty_set_time()` API for programmatic time edits
+- JSON state persistence for `phase2_tenths` field (backwards compatible — old state files load with phase2 defaulting to 0)
+
+### Fixed
+- Clock adjust at 0:00 no longer reduces penalty time — pressing -1 min or -1 sec when the period clock is already at 0:00 was incorrectly subtracting time from active penalties
+- File watcher re-read no longer wipes compound penalty phase 2 data — `parse_penalty_files` now preserves `phase2_tenths` across text file round-trips
+
+### Changed
+- Penalty hotkeys now open a dialog for player number entry instead of silently adding penalties with no player number — ensures every penalty is tracked to a player
+- Clearing a compound penalty in phase 1 (via X button or Clear hotkey) transitions to phase 2 instead of removing the penalty entirely; clearing in phase 2 removes it as normal
+- Editing a compound penalty's time to 0 transitions to phase 2 instead of clearing
+- After clearing or expiring a penalty, remaining penalties consolidate to the lowest slots — "Clear 1" always targets the first remaining penalty regardless of which slot originally held it
+- Hotkey penalty-add callbacks now dispatch to the Qt main thread via `QMetaObject::invokeMethod` for thread-safe dialog display
+- Total OBS hotkeys increased from 37 to 45
+
 ## [0.5.1] - 2026-03-27
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.21)
 
-project(streamn_obs_scoreboard VERSION 0.5.1 LANGUAGES C CXX)
+project(streamn_obs_scoreboard VERSION 0.6.0 LANGUAGES C CXX)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ OBS Studio plugin that tracks live game scoreboard state and writes it to indivi
 - **7 sport presets** — hockey, basketball, soccer, football, lacrosse, rugby, and generic
 - **17 text files** updated in real-time: clock, period, scores, shots, team names, penalties, fouls, and sport
 - **Dock UI** with full scoreboard controls in an OBS dock panel
-- **31 OBS hotkeys** for hands-free operation during broadcasts
-- **Penalty tracking** with automatic countdown timers (hockey, lacrosse, rugby)
+- **45 OBS hotkeys** for hands-free operation during broadcasts
+- **Penalty tracking** with automatic countdown timers, compound penalties (2+2, 2+5, 2+10), edit/clear per slot (hockey, lacrosse, rugby)
 - **Foul/card counters** for basketball, soccer, and football
 - **reeln-cli integration** for automated highlight generation
 - **Game event timestamps** — YouTube chapter markers copied to clipboard for livestream descriptions
@@ -138,7 +138,7 @@ Not all files are relevant for every sport — shots are only tracked for hockey
 
 ## Hotkeys
 
-All 31 hotkeys are prefixed with "Streamn:" in OBS Settings > Hotkeys:
+All 45 hotkeys are prefixed with "Streamn:" in OBS Settings > Hotkeys:
 
 | Hotkey | Action |
 |--------|--------|
@@ -149,8 +149,13 @@ All 31 hotkeys are prefixed with "Streamn:" in OBS Settings > Hotkeys:
 | Home/Away Goal +/- | Adjust score (4 hotkeys) |
 | Home/Away Shot +/- | Adjust shots (4 hotkeys) |
 | Period Advance / Rewind | Change period |
-| Home/Away Penalty Add | Add penalty with default duration |
-| Home/Away Penalty Clear 1/2 | Clear penalty slot (4 hotkeys) |
+| Home/Away Penalty Add | Open add-penalty dialog (minor) |
+| Home/Away Major Penalty Add | Open add-penalty dialog (major) |
+| Home/Away 2+2 Penalty Add | Open add-penalty dialog (compound 2+2) |
+| Home/Away 2+5 Penalty Add | Open add-penalty dialog (compound 2+5) |
+| Home/Away Penalty Clear 1/2 | Clear or transition penalty slot (4 hotkeys) |
+| Home/Away Penalty Edit 1/2 | Open edit dialog for penalty slot (4 hotkeys) |
+| Home/Away Faceoff +/- | Adjust faceoff counter (4 hotkeys) |
 | Generate Highlights | Trigger reeln-cli highlight generation |
 | Home/Away Foul +/- | Adjust foul counter (4 hotkeys) |
 | Home/Away Foul2 +/- | Adjust second foul counter (4 hotkeys) |

--- a/include/scoreboard-core.h
+++ b/include/scoreboard-core.h
@@ -56,6 +56,7 @@ struct scoreboard_penalty {
 	int player_number;
 	int remaining_tenths;
 	bool active;
+	int phase2_tenths; /* 0 = no second phase (compound penalties) */
 };
 
 /* Lifecycle */
@@ -166,15 +167,22 @@ void scoreboard_decrement_away_fouls2(void);
 
 /* Penalties (up to SCOREBOARD_MAX_PENALTIES per team) */
 int scoreboard_home_penalty_add(int player_number, int duration_secs);
+int scoreboard_home_penalty_add_compound(int player_number, int phase1_secs,
+					 int phase2_secs);
 void scoreboard_home_penalty_clear(int slot);
+void scoreboard_home_penalty_set_time(int slot, int duration_secs);
 const struct scoreboard_penalty *scoreboard_get_home_penalty(int slot);
 int scoreboard_get_home_penalty_count(void);
 int scoreboard_away_penalty_add(int player_number, int duration_secs);
+int scoreboard_away_penalty_add_compound(int player_number, int phase1_secs,
+					 int phase2_secs);
 void scoreboard_away_penalty_clear(int slot);
+void scoreboard_away_penalty_set_time(int slot, int duration_secs);
 const struct scoreboard_penalty *scoreboard_get_away_penalty(int slot);
 int scoreboard_get_away_penalty_count(void);
 void scoreboard_penalty_tick(int elapsed_tenths);
 void scoreboard_penalty_adjust(int delta_tenths);
+void scoreboard_penalty_compact(void);
 void scoreboard_format_penalty_number(int slot, bool home, char *buf,
 				      size_t size);
 void scoreboard_format_penalty_time(int slot, bool home, char *buf,

--- a/src/plugin-dock.cpp
+++ b/src/plugin-dock.cpp
@@ -82,6 +82,7 @@ struct process_job {
 struct penalty_row_widgets {
 	QWidget *container = nullptr;
 	QLabel *label = nullptr;
+	QPushButton *edit_btn = nullptr;
 	QPushButton *clear_btn = nullptr;
 	int slot = -1;
 	bool home = true;
@@ -158,7 +159,7 @@ struct recording_chapter {
 };
 QVector<recording_chapter> g_recording_chapters;
 
-static const int kNumHotkeys = 37;
+static const int kNumHotkeys = 45;
 
 static const char *kHotkeyNames[kNumHotkeys] = {
 	"sb_clock_startstop",  "sb_clock_reset",
@@ -180,6 +181,10 @@ static const char *kHotkeyNames[kNumHotkeys] = {
 	"sb_home_major_pen_add", "sb_away_major_pen_add",
 	"sb_home_fo_plus",     "sb_home_fo_minus",
 	"sb_away_fo_plus",     "sb_away_fo_minus",
+	"sb_home_2plus2_pen_add", "sb_away_2plus2_pen_add",
+	"sb_home_2plus5_pen_add", "sb_away_2plus5_pen_add",
+	"sb_home_pen_edit1",   "sb_home_pen_edit2",
+	"sb_away_pen_edit1",   "sb_away_pen_edit2",
 };
 
 obs_hotkey_id g_hotkey_ids[kNumHotkeys];
@@ -835,6 +840,7 @@ void run_reeln_highlights_command()
 }
 
 void write_files_now();
+void open_edit_penalty_dialog(QWidget *parent, bool home, int slot);
 
 /* ---- UI update ---- */
 
@@ -984,6 +990,18 @@ void update_all_labels()
 					sizeof(tbuf));
 				QString text = QString::fromUtf8(nbuf)
 					+ " " + QString::fromUtf8(tbuf);
+				const struct scoreboard_penalty *pen =
+					pw->home
+					? scoreboard_get_home_penalty(pw->slot)
+					: scoreboard_get_away_penalty(pw->slot);
+				if (pen && pen->phase2_tenths > 0) {
+					int p2s = pen->phase2_tenths / 10;
+					char p2buf[16];
+					snprintf(p2buf, sizeof(p2buf),
+						 " (+%d:%02d)",
+						 p2s / 60, p2s % 60);
+					text += QString::fromUtf8(p2buf);
+				}
 				if (idx >= SCOREBOARD_MAX_RUNNING_PENALTIES)
 					text += " (queued)";
 				pw->label->setText(text);
@@ -1020,18 +1038,44 @@ void update_all_labels()
 
 			QString text = QString::fromUtf8(nbuf) + " " +
 				QString::fromUtf8(tbuf);
+			const struct scoreboard_penalty *pen =
+				home ? scoreboard_get_home_penalty(i)
+				     : scoreboard_get_away_penalty(i);
+			if (pen && pen->phase2_tenths > 0) {
+				int p2s = pen->phase2_tenths / 10;
+				char p2buf[16];
+				snprintf(p2buf, sizeof(p2buf),
+					 " (+%d:%02d)",
+					 p2s / 60, p2s % 60);
+				text += QString::fromUtf8(p2buf);
+			}
 			if (row_idx >= SCOREBOARD_MAX_RUNNING_PENALTIES)
 				text += " (queued)";
 			pw->label = new QLabel(text);
 			pw->label->setStyleSheet("font-size: 11px;");
 			row_idx++;
+
+			const char *btn_style =
+				"QPushButton { padding: 0px; min-height: 16px; max-height: 18px; font-size: 10px; }";
+
+			pw->edit_btn = new QPushButton("\u270F");
+			pw->edit_btn->setFixedSize(18, 18);
+			pw->edit_btn->setStyleSheet(btn_style);
+
 			pw->clear_btn = new QPushButton("X");
 			pw->clear_btn->setFixedSize(18, 18);
-			pw->clear_btn->setStyleSheet(
-				"QPushButton { padding: 0px; min-height: 16px; max-height: 18px; font-size: 10px; }");
+			pw->clear_btn->setStyleSheet(btn_style);
 
 			int captured_slot = i;
 			bool captured_home = home;
+			QObject::connect(
+				pw->edit_btn, &QPushButton::clicked,
+				[parent_widget, captured_slot,
+				 captured_home]() {
+					open_edit_penalty_dialog(
+						parent_widget, captured_home,
+						captured_slot);
+				});
 			QObject::connect(
 				pw->clear_btn, &QPushButton::clicked,
 				[captured_slot, captured_home]() {
@@ -1039,21 +1083,35 @@ void update_all_labels()
 						captured_home
 						? scoreboard_get_home_penalty(captured_slot)
 						: scoreboard_get_away_penalty(captured_slot);
-					if (p && p->active)
+					if (!p || !p->active)
+						return;
+					/* Compound phase 1: transition to
+					   phase 2. Otherwise: full clear. */
+					if (p->phase2_tenths > 0) {
+						if (captured_home)
+							scoreboard_home_penalty_set_time(
+								captured_slot, 0);
+						else
+							scoreboard_away_penalty_set_time(
+								captured_slot, 0);
+					} else {
 						remove_penalty_event(
 							captured_home,
 							p->player_number);
-					if (captured_home)
-						scoreboard_home_penalty_clear(
-							captured_slot);
-					else
-						scoreboard_away_penalty_clear(
-							captured_slot);
+						if (captured_home)
+							scoreboard_home_penalty_clear(
+								captured_slot);
+						else
+							scoreboard_away_penalty_clear(
+								captured_slot);
+						scoreboard_penalty_compact();
+					}
 					write_files_now();
 					update_all_labels();
 				});
 
 			hl->addWidget(pw->label, 1);
+			hl->addWidget(pw->edit_btn);
 			hl->addWidget(pw->clear_btn);
 			layout->addWidget(pw->container);
 			rows.push_back(pw);
@@ -1212,16 +1270,19 @@ void update_highlights_button_visibility()
 /* ---- Dialogs ---- */
 
 void open_add_penalty_dialog(QWidget *parent, bool home,
-			     int default_duration_secs = 0)
+			     int default_duration_secs = 0,
+			     int phase2_secs = 0)
 {
 	QDialog dialog(parent);
 	dialog.setWindowTitle(home ? "Add Home Penalty" : "Add Away Penalty");
+	dialog.raise();
+	dialog.activateWindow();
 	QVBoxLayout *layout = new QVBoxLayout(&dialog);
 
 	QHBoxLayout *num_row = new QHBoxLayout();
 	num_row->addWidget(new QLabel("Player #:", &dialog));
 	QLineEdit *num_input = new QLineEdit(&dialog);
-	num_input->setPlaceholderText("optional");
+	num_input->setPlaceholderText("required");
 	num_row->addWidget(num_input);
 	layout->addLayout(num_row);
 
@@ -1236,6 +1297,140 @@ void open_add_penalty_dialog(QWidget *parent, bool home,
 	dur_row->addWidget(dur_spin);
 	layout->addLayout(dur_row);
 
+	/* Phase 2 toggle buttons — only for sports with major penalties */
+	QPushButton *p2_btn_2 = nullptr;
+	QPushButton *p2_btn_5 = nullptr;
+	QPushButton *p2_btn_10 = nullptr;
+	const struct scoreboard_sport_preset *preset =
+		scoreboard_get_sport_preset();
+	bool show_compound =
+		preset && preset->has_penalties &&
+		preset->default_major_penalty_secs > 0;
+
+	if (show_compound) {
+		QHBoxLayout *p2_row = new QHBoxLayout();
+		p2_row->addWidget(new QLabel("Phase 2:", &dialog));
+		p2_btn_2 = new QPushButton("+2", &dialog);
+		p2_btn_5 = new QPushButton("+5", &dialog);
+		p2_btn_10 = new QPushButton("+10", &dialog);
+		p2_btn_2->setCheckable(true);
+		p2_btn_5->setCheckable(true);
+		p2_btn_10->setCheckable(true);
+
+		/* Pre-select based on phase2_secs parameter */
+		if (phase2_secs == scoreboard_get_default_penalty_duration())
+			p2_btn_2->setChecked(true);
+		else if (phase2_secs ==
+			 scoreboard_get_default_major_penalty_duration())
+			p2_btn_5->setChecked(true);
+		else if (phase2_secs == 600)
+			p2_btn_10->setChecked(true);
+
+		/* Exclusive + deselectable: clicking a checked button
+		   unchecks it; clicking another unchecks the rest */
+		auto toggle = [=](QPushButton *clicked) {
+			if (clicked->isChecked()) {
+				if (clicked != p2_btn_2)
+					p2_btn_2->setChecked(false);
+				if (clicked != p2_btn_5)
+					p2_btn_5->setChecked(false);
+				if (clicked != p2_btn_10)
+					p2_btn_10->setChecked(false);
+			}
+		};
+		QObject::connect(p2_btn_2, &QPushButton::clicked,
+				 [=]() { toggle(p2_btn_2); });
+		QObject::connect(p2_btn_5, &QPushButton::clicked,
+				 [=]() { toggle(p2_btn_5); });
+		QObject::connect(p2_btn_10, &QPushButton::clicked,
+				 [=]() { toggle(p2_btn_10); });
+
+		p2_row->addWidget(p2_btn_2);
+		p2_row->addWidget(p2_btn_5);
+		p2_row->addWidget(p2_btn_10);
+		layout->addLayout(p2_row);
+	}
+
+	QDialogButtonBox *buttons = new QDialogButtonBox(
+		QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
+	QObject::connect(buttons, &QDialogButtonBox::accepted, &dialog,
+			 &QDialog::accept);
+	QObject::connect(buttons, &QDialogButtonBox::rejected, &dialog,
+			 &QDialog::reject);
+	layout->addWidget(buttons);
+
+	num_input->setFocus();
+
+	if (dialog.exec() == QDialog::Accepted) {
+		bool ok = false;
+		int player_num = num_input->text().trimmed().toInt(&ok);
+		if (!ok)
+			player_num = 0;
+
+		/* Determine phase 2 from toggle state */
+		int selected_phase2 = 0;
+		if (p2_btn_2 && p2_btn_2->isChecked())
+			selected_phase2 =
+				scoreboard_get_default_penalty_duration();
+		else if (p2_btn_5 && p2_btn_5->isChecked())
+			selected_phase2 =
+				scoreboard_get_default_major_penalty_duration();
+		else if (p2_btn_10 && p2_btn_10->isChecked())
+			selected_phase2 = 600;
+
+		int slot;
+		if (selected_phase2 > 0) {
+			if (home)
+				slot = scoreboard_home_penalty_add_compound(
+					player_num, dur_spin->value(),
+					selected_phase2);
+			else
+				slot = scoreboard_away_penalty_add_compound(
+					player_num, dur_spin->value(),
+					selected_phase2);
+		} else {
+			if (home)
+				slot = scoreboard_home_penalty_add(
+					player_num, dur_spin->value());
+			else
+				slot = scoreboard_away_penalty_add(
+					player_num, dur_spin->value());
+		}
+		if (slot >= 0)
+			log_penalty_event(home, player_num);
+		else
+			log_info("[streamn-obs-scoreboard] penalty slots full");
+		update_all_labels();
+	}
+}
+
+void open_edit_penalty_dialog(QWidget *parent, bool home, int slot)
+{
+	const struct scoreboard_penalty *p =
+		home ? scoreboard_get_home_penalty(slot)
+		     : scoreboard_get_away_penalty(slot);
+	if (!p || !p->active)
+		return;
+
+	QDialog dialog(parent);
+	char title_buf[64];
+	snprintf(title_buf, sizeof(title_buf), "Edit %s Penalty #%d",
+		 home ? "Home" : "Away", p->player_number);
+	dialog.setWindowTitle(QString::fromUtf8(title_buf));
+	dialog.raise();
+	dialog.activateWindow();
+	QVBoxLayout *layout = new QVBoxLayout(&dialog);
+
+	int current_secs = p->remaining_tenths / 10;
+
+	QHBoxLayout *dur_row = new QHBoxLayout();
+	dur_row->addWidget(new QLabel("Remaining (sec):", &dialog));
+	QSpinBox *dur_spin = new QSpinBox(&dialog);
+	dur_spin->setRange(0, 1200);
+	dur_spin->setValue(current_secs);
+	dur_row->addWidget(dur_spin);
+	layout->addLayout(dur_row);
+
 	QDialogButtonBox *buttons = new QDialogButtonBox(
 		QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
 	QObject::connect(buttons, &QDialogButtonBox::accepted, &dialog,
@@ -1245,21 +1440,13 @@ void open_add_penalty_dialog(QWidget *parent, bool home,
 	layout->addWidget(buttons);
 
 	if (dialog.exec() == QDialog::Accepted) {
-		bool ok = false;
-		int player_num = num_input->text().trimmed().toInt(&ok);
-		if (!ok)
-			player_num = 0;
-		int slot;
 		if (home)
-			slot = scoreboard_home_penalty_add(player_num,
-							   dur_spin->value());
+			scoreboard_home_penalty_set_time(slot,
+							 dur_spin->value());
 		else
-			slot = scoreboard_away_penalty_add(player_num,
-							   dur_spin->value());
-		if (slot >= 0)
-			log_penalty_event(home, player_num);
-		else
-			log_info("[streamn-obs-scoreboard] penalty slots full");
+			scoreboard_away_penalty_set_time(slot,
+							 dur_spin->value());
+		write_files_now();
 		update_all_labels();
 	}
 }
@@ -1788,12 +1975,12 @@ void hk_period_rewind(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
 
 void hk_home_pen_add(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
 {
-	if (!pressed)
+	if (!pressed || !g_dock_widget)
 		return;
-	int slot = scoreboard_home_penalty_add(
-		0, scoreboard_get_default_penalty_duration());
-	if (slot >= 0)
-		log_penalty_event(true, 0);
+	QMetaObject::invokeMethod(
+		g_dock_widget,
+		[=]() { open_add_penalty_dialog(g_dock_widget, true); },
+		Qt::QueuedConnection);
 }
 
 void hk_home_pen_clear1(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
@@ -1801,9 +1988,15 @@ void hk_home_pen_clear1(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
 	if (!pressed)
 		return;
 	const struct scoreboard_penalty *p = scoreboard_get_home_penalty(0);
-	if (p && p->active)
+	if (!p || !p->active)
+		return;
+	if (p->phase2_tenths > 0) {
+		scoreboard_home_penalty_set_time(0, 0);
+	} else {
 		remove_penalty_event(true, p->player_number);
-	scoreboard_home_penalty_clear(0);
+		scoreboard_home_penalty_clear(0);
+		scoreboard_penalty_compact();
+	}
 }
 
 void hk_home_pen_clear2(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
@@ -1811,19 +2004,25 @@ void hk_home_pen_clear2(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
 	if (!pressed)
 		return;
 	const struct scoreboard_penalty *p = scoreboard_get_home_penalty(1);
-	if (p && p->active)
+	if (!p || !p->active)
+		return;
+	if (p->phase2_tenths > 0) {
+		scoreboard_home_penalty_set_time(1, 0);
+	} else {
 		remove_penalty_event(true, p->player_number);
-	scoreboard_home_penalty_clear(1);
+		scoreboard_home_penalty_clear(1);
+		scoreboard_penalty_compact();
+	}
 }
 
 void hk_away_pen_add(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
 {
-	if (!pressed)
+	if (!pressed || !g_dock_widget)
 		return;
-	int slot = scoreboard_away_penalty_add(
-		0, scoreboard_get_default_penalty_duration());
-	if (slot >= 0)
-		log_penalty_event(false, 0);
+	QMetaObject::invokeMethod(
+		g_dock_widget,
+		[=]() { open_add_penalty_dialog(g_dock_widget, false); },
+		Qt::QueuedConnection);
 }
 
 void hk_away_pen_clear1(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
@@ -1831,9 +2030,15 @@ void hk_away_pen_clear1(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
 	if (!pressed)
 		return;
 	const struct scoreboard_penalty *p = scoreboard_get_away_penalty(0);
-	if (p && p->active)
+	if (!p || !p->active)
+		return;
+	if (p->phase2_tenths > 0) {
+		scoreboard_away_penalty_set_time(0, 0);
+	} else {
 		remove_penalty_event(false, p->player_number);
-	scoreboard_away_penalty_clear(0);
+		scoreboard_away_penalty_clear(0);
+		scoreboard_penalty_compact();
+	}
 }
 
 void hk_away_pen_clear2(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
@@ -1841,29 +2046,145 @@ void hk_away_pen_clear2(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
 	if (!pressed)
 		return;
 	const struct scoreboard_penalty *p = scoreboard_get_away_penalty(1);
-	if (p && p->active)
+	if (!p || !p->active)
+		return;
+	if (p->phase2_tenths > 0) {
+		scoreboard_away_penalty_set_time(1, 0);
+	} else {
 		remove_penalty_event(false, p->player_number);
-	scoreboard_away_penalty_clear(1);
+		scoreboard_away_penalty_clear(1);
+		scoreboard_penalty_compact();
+	}
 }
 
 void hk_home_major_pen_add(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
 {
-	if (!pressed)
+	if (!pressed || !g_dock_widget)
 		return;
-	int slot = scoreboard_home_penalty_add(
-		0, scoreboard_get_default_major_penalty_duration());
-	if (slot >= 0)
-		log_penalty_event(true, 0);
+	QMetaObject::invokeMethod(
+		g_dock_widget,
+		[=]() {
+			open_add_penalty_dialog(
+				g_dock_widget, true,
+				scoreboard_get_default_major_penalty_duration());
+		},
+		Qt::QueuedConnection);
 }
 
 void hk_away_major_pen_add(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
 {
-	if (!pressed)
+	if (!pressed || !g_dock_widget)
 		return;
-	int slot = scoreboard_away_penalty_add(
-		0, scoreboard_get_default_major_penalty_duration());
-	if (slot >= 0)
-		log_penalty_event(false, 0);
+	QMetaObject::invokeMethod(
+		g_dock_widget,
+		[=]() {
+			open_add_penalty_dialog(
+				g_dock_widget, false,
+				scoreboard_get_default_major_penalty_duration());
+		},
+		Qt::QueuedConnection);
+}
+
+void hk_home_2plus2_pen_add(void *, obs_hotkey_id, obs_hotkey_t *,
+			     bool pressed)
+{
+	if (!pressed || !g_dock_widget)
+		return;
+	int minor = scoreboard_get_default_penalty_duration();
+	QMetaObject::invokeMethod(
+		g_dock_widget,
+		[=]() {
+			open_add_penalty_dialog(g_dock_widget, true, minor,
+						minor);
+		},
+		Qt::QueuedConnection);
+}
+
+void hk_away_2plus2_pen_add(void *, obs_hotkey_id, obs_hotkey_t *,
+			     bool pressed)
+{
+	if (!pressed || !g_dock_widget)
+		return;
+	int minor = scoreboard_get_default_penalty_duration();
+	QMetaObject::invokeMethod(
+		g_dock_widget,
+		[=]() {
+			open_add_penalty_dialog(g_dock_widget, false, minor,
+						minor);
+		},
+		Qt::QueuedConnection);
+}
+
+void hk_home_2plus5_pen_add(void *, obs_hotkey_id, obs_hotkey_t *,
+			     bool pressed)
+{
+	if (!pressed || !g_dock_widget)
+		return;
+	int minor = scoreboard_get_default_penalty_duration();
+	int major = scoreboard_get_default_major_penalty_duration();
+	QMetaObject::invokeMethod(
+		g_dock_widget,
+		[=]() {
+			open_add_penalty_dialog(g_dock_widget, true, minor,
+						major);
+		},
+		Qt::QueuedConnection);
+}
+
+void hk_away_2plus5_pen_add(void *, obs_hotkey_id, obs_hotkey_t *,
+			     bool pressed)
+{
+	if (!pressed || !g_dock_widget)
+		return;
+	int minor = scoreboard_get_default_penalty_duration();
+	int major = scoreboard_get_default_major_penalty_duration();
+	QMetaObject::invokeMethod(
+		g_dock_widget,
+		[=]() {
+			open_add_penalty_dialog(g_dock_widget, false, minor,
+						major);
+		},
+		Qt::QueuedConnection);
+}
+
+void hk_home_pen_edit1(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
+{
+	if (!pressed || !g_dock_widget)
+		return;
+	QMetaObject::invokeMethod(
+		g_dock_widget,
+		[=]() { open_edit_penalty_dialog(g_dock_widget, true, 0); },
+		Qt::QueuedConnection);
+}
+
+void hk_home_pen_edit2(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
+{
+	if (!pressed || !g_dock_widget)
+		return;
+	QMetaObject::invokeMethod(
+		g_dock_widget,
+		[=]() { open_edit_penalty_dialog(g_dock_widget, true, 1); },
+		Qt::QueuedConnection);
+}
+
+void hk_away_pen_edit1(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
+{
+	if (!pressed || !g_dock_widget)
+		return;
+	QMetaObject::invokeMethod(
+		g_dock_widget,
+		[=]() { open_edit_penalty_dialog(g_dock_widget, false, 0); },
+		Qt::QueuedConnection);
+}
+
+void hk_away_pen_edit2(void *, obs_hotkey_id, obs_hotkey_t *, bool pressed)
+{
+	if (!pressed || !g_dock_widget)
+		return;
+	QMetaObject::invokeMethod(
+		g_dock_widget,
+		[=]() { open_edit_penalty_dialog(g_dock_widget, false, 1); },
+		Qt::QueuedConnection);
 }
 
 void hk_generate_highlights(void *, obs_hotkey_id, obs_hotkey_t *,
@@ -2089,6 +2410,38 @@ void register_hotkeys()
 	g_hotkey_ids[idx++] = obs_hotkey_register_frontend(
 		"sb_away_fo_minus", "Streamn: Away Faceoff -",
 		hk_away_fo_minus, nullptr);
+	g_hotkey_ids[idx++] = obs_hotkey_register_frontend(
+		"sb_home_2plus2_pen_add",
+		"Streamn: Home 2+2 Penalty Add",
+		hk_home_2plus2_pen_add, nullptr);
+	g_hotkey_ids[idx++] = obs_hotkey_register_frontend(
+		"sb_away_2plus2_pen_add",
+		"Streamn: Away 2+2 Penalty Add",
+		hk_away_2plus2_pen_add, nullptr);
+	g_hotkey_ids[idx++] = obs_hotkey_register_frontend(
+		"sb_home_2plus5_pen_add",
+		"Streamn: Home 2+5 Penalty Add",
+		hk_home_2plus5_pen_add, nullptr);
+	g_hotkey_ids[idx++] = obs_hotkey_register_frontend(
+		"sb_away_2plus5_pen_add",
+		"Streamn: Away 2+5 Penalty Add",
+		hk_away_2plus5_pen_add, nullptr);
+	g_hotkey_ids[idx++] = obs_hotkey_register_frontend(
+		"sb_home_pen_edit1",
+		"Streamn: Home Penalty Edit 1",
+		hk_home_pen_edit1, nullptr);
+	g_hotkey_ids[idx++] = obs_hotkey_register_frontend(
+		"sb_home_pen_edit2",
+		"Streamn: Home Penalty Edit 2",
+		hk_home_pen_edit2, nullptr);
+	g_hotkey_ids[idx++] = obs_hotkey_register_frontend(
+		"sb_away_pen_edit1",
+		"Streamn: Away Penalty Edit 1",
+		hk_away_pen_edit1, nullptr);
+	g_hotkey_ids[idx++] = obs_hotkey_register_frontend(
+		"sb_away_pen_edit2",
+		"Streamn: Away Penalty Edit 2",
+		hk_away_pen_edit2, nullptr);
 
 	/* Register save/load callbacks to persist hotkey bindings */
 	obs_frontend_add_save_callback(save_hotkeys, nullptr);

--- a/src/scoreboard-core.c
+++ b/src/scoreboard-core.c
@@ -173,6 +173,17 @@ static int parse_period_text(const char *text)
 static void parse_penalty_files(const char *numbers_text,
 				const char *times_text, bool home)
 {
+	/* Save phase2_tenths before clearing — text files cannot carry
+	   compound phase info, so we preserve it for matching penalties */
+	struct scoreboard_penalty *penalties =
+		home ? g_state.home_penalties : g_state.away_penalties;
+	int saved_phase2[SCOREBOARD_PENALTY_SLOTS];
+	int saved_player[SCOREBOARD_PENALTY_SLOTS];
+	for (int i = 0; i < SCOREBOARD_PENALTY_SLOTS; i++) {
+		saved_phase2[i] = penalties[i].phase2_tenths;
+		saved_player[i] = penalties[i].player_number;
+	}
+
 	/* Clear all existing penalties for this team */
 	for (int i = 0; i < SCOREBOARD_PENALTY_SLOTS; i++) {
 		if (home)
@@ -212,12 +223,30 @@ static void parse_penalty_files(const char *numbers_text,
 		if (sscanf(tline, "%d:%d", &minutes, &seconds) == 2) {
 			int duration_secs = minutes * 60 + seconds;
 			if (duration_secs > 0) {
+				int slot;
 				if (home)
-					scoreboard_home_penalty_add(
+					slot = scoreboard_home_penalty_add(
 						player, duration_secs);
 				else
-					scoreboard_away_penalty_add(
+					slot = scoreboard_away_penalty_add(
 						player, duration_secs);
+				/* Restore phase2_tenths if the same player
+				   had compound data before the re-parse */
+				if (slot >= 0) {
+					for (int j = 0;
+					     j < SCOREBOARD_PENALTY_SLOTS;
+					     j++) {
+						if (saved_player[j] ==
+							    player &&
+						    saved_phase2[j] > 0) {
+							penalties[slot]
+								.phase2_tenths =
+								saved_phase2[j];
+							saved_phase2[j] = 0;
+							break;
+						}
+					}
+				}
 			}
 		}
 
@@ -429,20 +458,26 @@ void scoreboard_clock_set_tenths(int tenths)
 
 void scoreboard_clock_adjust_seconds(int delta)
 {
+	int before = g_state.clock_tenths;
 	g_state.clock_tenths += delta * 10;
 	if (g_state.clock_tenths < 0)
 		g_state.clock_tenths = 0;
 	mark_dirty();
-	scoreboard_penalty_adjust(delta * 10);
+	int actual_delta = g_state.clock_tenths - before;
+	if (actual_delta != 0)
+		scoreboard_penalty_adjust(actual_delta);
 }
 
 void scoreboard_clock_adjust_minutes(int delta)
 {
+	int before = g_state.clock_tenths;
 	g_state.clock_tenths += delta * 600;
 	if (g_state.clock_tenths < 0)
 		g_state.clock_tenths = 0;
 	mark_dirty();
-	scoreboard_penalty_adjust(delta * 600);
+	int actual_delta = g_state.clock_tenths - before;
+	if (actual_delta != 0)
+		scoreboard_penalty_adjust(actual_delta);
 }
 
 void scoreboard_clock_format(char *buf, size_t size)
@@ -951,14 +986,56 @@ int scoreboard_home_penalty_add(int player_number, int duration_secs)
 	return -1;
 }
 
+int scoreboard_home_penalty_add_compound(int player_number, int phase1_secs,
+					 int phase2_secs)
+{
+	for (int i = 0; i < SCOREBOARD_PENALTY_SLOTS; i++) {
+		if (!g_state.home_penalties[i].active) {
+			g_state.home_penalties[i].player_number = player_number;
+			g_state.home_penalties[i].remaining_tenths =
+				phase1_secs * 10;
+			g_state.home_penalties[i].phase2_tenths =
+				phase2_secs * 10;
+			g_state.home_penalties[i].active = true;
+			mark_dirty();
+			return i;
+		}
+	}
+	return -1;
+}
+
 void scoreboard_home_penalty_clear(int slot)
 {
 	if (slot >= 0 && slot < SCOREBOARD_PENALTY_SLOTS) {
 		g_state.home_penalties[slot].active = false;
 		g_state.home_penalties[slot].player_number = 0;
 		g_state.home_penalties[slot].remaining_tenths = 0;
+		g_state.home_penalties[slot].phase2_tenths = 0;
 		mark_dirty();
 	}
+}
+
+void scoreboard_home_penalty_set_time(int slot, int duration_secs)
+{
+	if (slot < 0 || slot >= SCOREBOARD_PENALTY_SLOTS)
+		return;
+	if (!g_state.home_penalties[slot].active)
+		return;
+	if (duration_secs <= 0) {
+		if (g_state.home_penalties[slot].phase2_tenths > 0) {
+			g_state.home_penalties[slot].remaining_tenths =
+				g_state.home_penalties[slot].phase2_tenths;
+			g_state.home_penalties[slot].phase2_tenths = 0;
+		} else {
+			scoreboard_home_penalty_clear(slot);
+			scoreboard_penalty_compact();
+			return;
+		}
+	} else {
+		g_state.home_penalties[slot].remaining_tenths =
+			duration_secs * 10;
+	}
+	mark_dirty();
 }
 
 const struct scoreboard_penalty *scoreboard_get_home_penalty(int slot)
@@ -983,14 +1060,56 @@ int scoreboard_away_penalty_add(int player_number, int duration_secs)
 	return -1;
 }
 
+int scoreboard_away_penalty_add_compound(int player_number, int phase1_secs,
+					 int phase2_secs)
+{
+	for (int i = 0; i < SCOREBOARD_PENALTY_SLOTS; i++) {
+		if (!g_state.away_penalties[i].active) {
+			g_state.away_penalties[i].player_number = player_number;
+			g_state.away_penalties[i].remaining_tenths =
+				phase1_secs * 10;
+			g_state.away_penalties[i].phase2_tenths =
+				phase2_secs * 10;
+			g_state.away_penalties[i].active = true;
+			mark_dirty();
+			return i;
+		}
+	}
+	return -1;
+}
+
 void scoreboard_away_penalty_clear(int slot)
 {
 	if (slot >= 0 && slot < SCOREBOARD_PENALTY_SLOTS) {
 		g_state.away_penalties[slot].active = false;
 		g_state.away_penalties[slot].player_number = 0;
 		g_state.away_penalties[slot].remaining_tenths = 0;
+		g_state.away_penalties[slot].phase2_tenths = 0;
 		mark_dirty();
 	}
+}
+
+void scoreboard_away_penalty_set_time(int slot, int duration_secs)
+{
+	if (slot < 0 || slot >= SCOREBOARD_PENALTY_SLOTS)
+		return;
+	if (!g_state.away_penalties[slot].active)
+		return;
+	if (duration_secs <= 0) {
+		if (g_state.away_penalties[slot].phase2_tenths > 0) {
+			g_state.away_penalties[slot].remaining_tenths =
+				g_state.away_penalties[slot].phase2_tenths;
+			g_state.away_penalties[slot].phase2_tenths = 0;
+		} else {
+			scoreboard_away_penalty_clear(slot);
+			scoreboard_penalty_compact();
+			return;
+		}
+	} else {
+		g_state.away_penalties[slot].remaining_tenths =
+			duration_secs * 10;
+	}
+	mark_dirty();
 }
 
 const struct scoreboard_penalty *scoreboard_get_away_penalty(int slot)
@@ -1023,6 +1142,7 @@ int scoreboard_get_away_penalty_count(void)
 void scoreboard_penalty_tick(int elapsed_tenths)
 {
 	bool ticked = false;
+	bool cleared = false;
 	int home_running = 0;
 	int away_running = 0;
 	for (int i = 0; i < SCOREBOARD_PENALTY_SLOTS; i++) {
@@ -1032,8 +1152,20 @@ void scoreboard_penalty_tick(int elapsed_tenths)
 				elapsed_tenths;
 			home_running++;
 			ticked = true;
-			if (g_state.home_penalties[i].remaining_tenths <= 0)
-				scoreboard_home_penalty_clear(i);
+			if (g_state.home_penalties[i].remaining_tenths <= 0) {
+				if (g_state.home_penalties[i].phase2_tenths >
+				    0) {
+					g_state.home_penalties[i]
+						.remaining_tenths =
+						g_state.home_penalties[i]
+							.phase2_tenths;
+					g_state.home_penalties[i]
+						.phase2_tenths = 0;
+				} else {
+					scoreboard_home_penalty_clear(i);
+					cleared = true;
+				}
+			}
 		}
 		if (g_state.away_penalties[i].active &&
 		    away_running < SCOREBOARD_MAX_RUNNING_PENALTIES) {
@@ -1041,10 +1173,24 @@ void scoreboard_penalty_tick(int elapsed_tenths)
 				elapsed_tenths;
 			away_running++;
 			ticked = true;
-			if (g_state.away_penalties[i].remaining_tenths <= 0)
-				scoreboard_away_penalty_clear(i);
+			if (g_state.away_penalties[i].remaining_tenths <= 0) {
+				if (g_state.away_penalties[i].phase2_tenths >
+				    0) {
+					g_state.away_penalties[i]
+						.remaining_tenths =
+						g_state.away_penalties[i]
+							.phase2_tenths;
+					g_state.away_penalties[i]
+						.phase2_tenths = 0;
+				} else {
+					scoreboard_away_penalty_clear(i);
+					cleared = true;
+				}
+			}
 		}
 	}
+	if (cleared)
+		scoreboard_penalty_compact();
 	if (ticked)
 		mark_dirty();
 }
@@ -1052,6 +1198,7 @@ void scoreboard_penalty_tick(int elapsed_tenths)
 void scoreboard_penalty_adjust(int delta_tenths)
 {
 	bool adjusted = false;
+	bool cleared = false;
 	int home_running = 0;
 	int away_running = 0;
 	for (int i = 0; i < SCOREBOARD_PENALTY_SLOTS; i++) {
@@ -1061,8 +1208,20 @@ void scoreboard_penalty_adjust(int delta_tenths)
 				delta_tenths;
 			home_running++;
 			adjusted = true;
-			if (g_state.home_penalties[i].remaining_tenths <= 0)
-				scoreboard_home_penalty_clear(i);
+			if (g_state.home_penalties[i].remaining_tenths <= 0) {
+				if (g_state.home_penalties[i].phase2_tenths >
+				    0) {
+					g_state.home_penalties[i]
+						.remaining_tenths =
+						g_state.home_penalties[i]
+							.phase2_tenths;
+					g_state.home_penalties[i]
+						.phase2_tenths = 0;
+				} else {
+					scoreboard_home_penalty_clear(i);
+					cleared = true;
+				}
+			}
 		}
 		if (g_state.away_penalties[i].active &&
 		    away_running < SCOREBOARD_MAX_RUNNING_PENALTIES) {
@@ -1070,12 +1229,50 @@ void scoreboard_penalty_adjust(int delta_tenths)
 				delta_tenths;
 			away_running++;
 			adjusted = true;
-			if (g_state.away_penalties[i].remaining_tenths <= 0)
-				scoreboard_away_penalty_clear(i);
+			if (g_state.away_penalties[i].remaining_tenths <= 0) {
+				if (g_state.away_penalties[i].phase2_tenths >
+				    0) {
+					g_state.away_penalties[i]
+						.remaining_tenths =
+						g_state.away_penalties[i]
+							.phase2_tenths;
+					g_state.away_penalties[i]
+						.phase2_tenths = 0;
+				} else {
+					scoreboard_away_penalty_clear(i);
+					cleared = true;
+				}
+			}
 		}
 	}
+	if (cleared)
+		scoreboard_penalty_compact();
 	if (adjusted)
 		mark_dirty();
+}
+
+static void compact_penalties(struct scoreboard_penalty *penalties)
+{
+	int w = 0;
+	for (int r = 0; r < SCOREBOARD_PENALTY_SLOTS; r++) {
+		if (penalties[r].active) {
+			if (w != r)
+				penalties[w] = penalties[r];
+			w++;
+		}
+	}
+	for (int i = w; i < SCOREBOARD_PENALTY_SLOTS; i++) {
+		penalties[i].active = false;
+		penalties[i].player_number = 0;
+		penalties[i].remaining_tenths = 0;
+		penalties[i].phase2_tenths = 0;
+	}
+}
+
+void scoreboard_penalty_compact(void)
+{
+	compact_penalties(g_state.home_penalties);
+	compact_penalties(g_state.away_penalties);
 }
 
 void scoreboard_format_penalty_number(int slot, bool home, char *buf,
@@ -1443,6 +1640,8 @@ bool scoreboard_save_state(const char *path)
 			g_state.home_penalties[i].remaining_tenths);
 		fprintf(f, "  \"home_penalty%d_active\": %s,\n", i,
 			g_state.home_penalties[i].active ? "true" : "false");
+		fprintf(f, "  \"home_penalty%d_phase2_tenths\": %d,\n", i,
+			g_state.home_penalties[i].phase2_tenths);
 	}
 	for (int i = 0; i < SCOREBOARD_PENALTY_SLOTS; i++) {
 		fprintf(f, "  \"away_penalty%d_number\": %d,\n", i,
@@ -1451,6 +1650,8 @@ bool scoreboard_save_state(const char *path)
 			g_state.away_penalties[i].remaining_tenths);
 		fprintf(f, "  \"away_penalty%d_active\": %s,\n", i,
 			g_state.away_penalties[i].active ? "true" : "false");
+		fprintf(f, "  \"away_penalty%d_phase2_tenths\": %d,\n", i,
+			g_state.away_penalties[i].phase2_tenths);
 	}
 
 	fprintf(f, "  \"period_label_count\": %d",
@@ -1550,6 +1751,9 @@ bool scoreboard_load_state(const char *path)
 		snprintf(key, sizeof(key), "home_penalty%d_active", i);
 		g_state.home_penalties[i].active = parse_json_bool(
 			json, key, g_state.home_penalties[i].active);
+		snprintf(key, sizeof(key), "home_penalty%d_phase2_tenths", i);
+		g_state.home_penalties[i].phase2_tenths = parse_json_int(
+			json, key, g_state.home_penalties[i].phase2_tenths);
 
 		snprintf(key, sizeof(key), "away_penalty%d_number", i);
 		g_state.away_penalties[i].player_number = parse_json_int(
@@ -1560,6 +1764,9 @@ bool scoreboard_load_state(const char *path)
 		snprintf(key, sizeof(key), "away_penalty%d_active", i);
 		g_state.away_penalties[i].active = parse_json_bool(
 			json, key, g_state.away_penalties[i].active);
+		snprintf(key, sizeof(key), "away_penalty%d_phase2_tenths", i);
+		g_state.away_penalties[i].phase2_tenths = parse_json_int(
+			json, key, g_state.away_penalties[i].phase2_tenths);
 	}
 
 	{
@@ -1605,9 +1812,11 @@ void scoreboard_new_game(void)
 		g_state.home_penalties[i].active = false;
 		g_state.home_penalties[i].player_number = 0;
 		g_state.home_penalties[i].remaining_tenths = 0;
+		g_state.home_penalties[i].phase2_tenths = 0;
 		g_state.away_penalties[i].active = false;
 		g_state.away_penalties[i].player_number = 0;
 		g_state.away_penalties[i].remaining_tenths = 0;
+		g_state.away_penalties[i].phase2_tenths = 0;
 	}
 
 	if (g_state.clock_direction == SCOREBOARD_CLOCK_COUNT_DOWN)

--- a/tests/test-scoreboard-core-penalties.c
+++ b/tests/test-scoreboard-core-penalties.c
@@ -556,17 +556,19 @@ static void test_queued_penalty_starts_after_expiry(void)
 	/* Tick enough to expire slot 0 */
 	scoreboard_penalty_tick(10);
 
-	/* Slot 0 expired */
-	assert(!scoreboard_get_home_penalty(0)->active);
-	/* Slot 1 ticked */
-	assert(scoreboard_get_home_penalty(1)->remaining_tenths == 1190);
-	/* Slot 2 still queued — didn't tick this round */
-	assert(scoreboard_get_home_penalty(2)->remaining_tenths == 1200);
+	/* After compact: slot 1 (#20) moved to slot 0, slot 2 (#30) to slot 1 */
+	assert(scoreboard_get_home_penalty(0)->player_number == 20);
+	assert(scoreboard_get_home_penalty(0)->remaining_tenths == 1190);
+	/* Slot 1 (was queued) didn't tick this round */
+	assert(scoreboard_get_home_penalty(1)->player_number == 30);
+	assert(scoreboard_get_home_penalty(1)->remaining_tenths == 1200);
+	/* Slot 2 now empty */
+	assert(!scoreboard_get_home_penalty(2)->active);
 
-	/* Next tick: slot 2 is now one of the first 2 active, so it ticks */
+	/* Next tick: both slot 0 and slot 1 are now running */
 	scoreboard_penalty_tick(10);
-	assert(scoreboard_get_home_penalty(1)->remaining_tenths == 1180);
-	assert(scoreboard_get_home_penalty(2)->remaining_tenths == 1190);
+	assert(scoreboard_get_home_penalty(0)->remaining_tenths == 1180);
+	assert(scoreboard_get_home_penalty(1)->remaining_tenths == 1190);
 }
 
 static void test_penalty_adjust_only_running(void)
@@ -598,6 +600,386 @@ static void test_format_only_running_penalties(void)
 	scoreboard_format_all_penalty_times(true, times, sizeof(times));
 	assert(strcmp(nums, "#10\n#20") == 0);
 	assert(strcmp(times, "2:00\n1:00") == 0);
+}
+
+/* ---- compact tests ---- */
+
+static void test_compact_fills_gap(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add(10, 120);
+	scoreboard_home_penalty_add(20, 60);
+	scoreboard_home_penalty_add(30, 300);
+	scoreboard_home_penalty_clear(0);
+	scoreboard_penalty_compact();
+
+	assert(scoreboard_get_home_penalty(0)->active);
+	assert(scoreboard_get_home_penalty(0)->player_number == 20);
+	assert(scoreboard_get_home_penalty(1)->active);
+	assert(scoreboard_get_home_penalty(1)->player_number == 30);
+	assert(!scoreboard_get_home_penalty(2)->active);
+}
+
+static void test_compact_no_gaps(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add(10, 120);
+	scoreboard_home_penalty_add(20, 60);
+	scoreboard_home_penalty_add(30, 300);
+	scoreboard_penalty_compact();
+
+	assert(scoreboard_get_home_penalty(0)->player_number == 10);
+	assert(scoreboard_get_home_penalty(1)->player_number == 20);
+	assert(scoreboard_get_home_penalty(2)->player_number == 30);
+}
+
+static void test_compact_empty(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_penalty_compact();
+	assert(scoreboard_get_home_penalty_count() == 0);
+	assert(scoreboard_get_away_penalty_count() == 0);
+}
+
+static void test_compact_multiple_gaps(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add(10, 120);
+	scoreboard_home_penalty_add(20, 60);
+	scoreboard_home_penalty_add(30, 300);
+	scoreboard_home_penalty_add(40, 120);
+	scoreboard_home_penalty_clear(0);
+	scoreboard_home_penalty_clear(2);
+	scoreboard_penalty_compact();
+
+	assert(scoreboard_get_home_penalty(0)->player_number == 20);
+	assert(scoreboard_get_home_penalty(1)->player_number == 40);
+	assert(!scoreboard_get_home_penalty(2)->active);
+	assert(!scoreboard_get_home_penalty(3)->active);
+}
+
+static void test_compact_away(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_away_penalty_add(10, 120);
+	scoreboard_away_penalty_add(20, 60);
+	scoreboard_away_penalty_clear(0);
+	scoreboard_penalty_compact();
+
+	assert(scoreboard_get_away_penalty(0)->player_number == 20);
+	assert(!scoreboard_get_away_penalty(1)->active);
+}
+
+static void test_tick_expire_compacts(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add(10, 1);   /* 10 tenths — expires in 1 tick */
+	scoreboard_home_penalty_add(20, 120); /* running */
+	scoreboard_home_penalty_add(30, 120); /* queued */
+
+	scoreboard_penalty_tick(10);
+
+	/* After expire + compact: #20 in slot 0, #30 in slot 1 */
+	assert(scoreboard_get_home_penalty(0)->player_number == 20);
+	assert(scoreboard_get_home_penalty(1)->player_number == 30);
+	assert(!scoreboard_get_home_penalty(2)->active);
+}
+
+static void test_adjust_expire_compacts(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add(10, 5);   /* 50 tenths */
+	scoreboard_home_penalty_add(20, 120); /* running */
+	scoreboard_home_penalty_add(30, 120); /* queued */
+
+	scoreboard_penalty_adjust(-50);
+
+	/* #10 expired + compact: #20 in slot 0, #30 in slot 1 */
+	assert(scoreboard_get_home_penalty(0)->player_number == 20);
+	assert(scoreboard_get_home_penalty(1)->player_number == 30);
+	assert(!scoreboard_get_home_penalty(2)->active);
+}
+
+static void test_compact_preserves_phase2(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add(10, 120);
+	scoreboard_home_penalty_add_compound(20, 120, 120);
+	scoreboard_home_penalty_clear(0);
+	scoreboard_penalty_compact();
+
+	assert(scoreboard_get_home_penalty(0)->player_number == 20);
+	assert(scoreboard_get_home_penalty(0)->phase2_tenths == 1200);
+}
+
+/* ---- set_time tests ---- */
+
+static void test_home_penalty_set_time(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add(12, 120);
+	scoreboard_home_penalty_set_time(0, 60);
+	assert(scoreboard_get_home_penalty(0)->remaining_tenths == 600);
+}
+
+static void test_away_penalty_set_time(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_away_penalty_add(22, 120);
+	scoreboard_away_penalty_set_time(0, 60);
+	assert(scoreboard_get_away_penalty(0)->remaining_tenths == 600);
+}
+
+static void test_penalty_set_time_invalid_slot(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_set_time(-1, 60);
+	scoreboard_home_penalty_set_time(SCOREBOARD_MAX_PENALTIES, 60);
+	scoreboard_away_penalty_set_time(-1, 60);
+	scoreboard_away_penalty_set_time(SCOREBOARD_MAX_PENALTIES, 60);
+}
+
+static void test_penalty_set_time_inactive_slot(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_set_time(0, 60);
+	assert(!scoreboard_get_home_penalty(0)->active);
+}
+
+static void test_penalty_set_time_zero_clears(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add(12, 120);
+	scoreboard_home_penalty_add(20, 60);
+	scoreboard_home_penalty_set_time(0, 0);
+	/* After clear + compact: #20 moves to slot 0 */
+	assert(scoreboard_get_home_penalty(0)->player_number == 20);
+	assert(!scoreboard_get_home_penalty(1)->active);
+}
+
+static void test_dirty_penalty_set_time(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add(12, 120);
+	scoreboard_set_output_directory("/tmp");
+	scoreboard_mark_dirty();
+	scoreboard_write_all_files();
+	assert(!scoreboard_is_dirty());
+	scoreboard_home_penalty_set_time(0, 60);
+	assert(scoreboard_is_dirty());
+}
+
+/* ---- compound penalty tests ---- */
+
+static void test_compound_add_home(void)
+{
+	scoreboard_reset_state_for_tests();
+	int slot = scoreboard_home_penalty_add_compound(12, 120, 120);
+	assert(slot == 0);
+	const struct scoreboard_penalty *p = scoreboard_get_home_penalty(0);
+	assert(p->active);
+	assert(p->player_number == 12);
+	assert(p->remaining_tenths == 1200);
+	assert(p->phase2_tenths == 1200);
+}
+
+static void test_compound_add_away(void)
+{
+	scoreboard_reset_state_for_tests();
+	int slot = scoreboard_away_penalty_add_compound(22, 120, 300);
+	assert(slot == 0);
+	const struct scoreboard_penalty *p = scoreboard_get_away_penalty(0);
+	assert(p->active);
+	assert(p->player_number == 22);
+	assert(p->remaining_tenths == 1200);
+	assert(p->phase2_tenths == 3000);
+}
+
+static void test_compound_add_full(void)
+{
+	scoreboard_reset_state_for_tests();
+	for (int i = 0; i < SCOREBOARD_MAX_PENALTIES; i++)
+		scoreboard_home_penalty_add(i + 1, 120);
+	assert(scoreboard_home_penalty_add_compound(99, 120, 120) == -1);
+}
+
+static void test_compound_phase_transition(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add_compound(12, 120, 120);
+
+	/* Tick all of phase 1 */
+	scoreboard_penalty_tick(1200);
+
+	/* Penalty should still be active — now in phase 2 */
+	const struct scoreboard_penalty *p = scoreboard_get_home_penalty(0);
+	assert(p->active);
+	assert(p->remaining_tenths == 1200);
+	assert(p->phase2_tenths == 0);
+}
+
+static void test_compound_phase2_expires(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add_compound(12, 120, 120);
+
+	/* Tick through both phases */
+	scoreboard_penalty_tick(1200);
+	scoreboard_penalty_tick(1200);
+
+	assert(!scoreboard_get_home_penalty(0)->active);
+}
+
+static void test_compound_holds_slot(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add_compound(12, 120, 120); /* slot 0 */
+	scoreboard_home_penalty_add(20, 60);                /* slot 1 */
+
+	/* Tick to expire phase 1 of compound */
+	scoreboard_penalty_tick(1200);
+
+	/* Compound still in slot 0, regular in slot 1 expired */
+	assert(scoreboard_get_home_penalty(0)->active);
+	assert(scoreboard_get_home_penalty(0)->player_number == 12);
+	assert(!scoreboard_get_home_penalty(1)->active);
+}
+
+static void test_compound_clear_removes_both(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add_compound(12, 120, 120);
+	scoreboard_home_penalty_clear(0);
+	assert(!scoreboard_get_home_penalty(0)->active);
+	assert(scoreboard_get_home_penalty(0)->phase2_tenths == 0);
+	assert(scoreboard_get_home_penalty(0)->remaining_tenths == 0);
+}
+
+static void test_compound_adjust_phase_transition(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add_compound(12, 5, 120);
+
+	scoreboard_penalty_adjust(-50);
+
+	const struct scoreboard_penalty *p = scoreboard_get_home_penalty(0);
+	assert(p->active);
+	assert(p->remaining_tenths == 1200);
+	assert(p->phase2_tenths == 0);
+}
+
+static void test_compound_away_phase_transition(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_away_penalty_add_compound(22, 120, 300);
+
+	scoreboard_penalty_tick(1200);
+
+	const struct scoreboard_penalty *p = scoreboard_get_away_penalty(0);
+	assert(p->active);
+	assert(p->remaining_tenths == 3000);
+	assert(p->phase2_tenths == 0);
+}
+
+static void test_compound_away_adjust_transition(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_away_penalty_add_compound(22, 5, 120);
+
+	scoreboard_penalty_adjust(-50);
+
+	const struct scoreboard_penalty *p = scoreboard_get_away_penalty(0);
+	assert(p->active);
+	assert(p->remaining_tenths == 1200);
+	assert(p->phase2_tenths == 0);
+}
+
+static void test_compound_counts_as_one_running(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add_compound(12, 120, 120); /* running */
+	scoreboard_home_penalty_add(20, 120);               /* running */
+	scoreboard_home_penalty_add(30, 120);               /* queued */
+
+	scoreboard_penalty_tick(10);
+
+	/* Compound and #20 ticked, #30 queued */
+	assert(scoreboard_get_home_penalty(0)->remaining_tenths == 1190);
+	assert(scoreboard_get_home_penalty(1)->remaining_tenths == 1190);
+	assert(scoreboard_get_home_penalty(2)->remaining_tenths == 1200);
+}
+
+static void test_compound_new_game_clears_phase2(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add_compound(12, 120, 120);
+	scoreboard_new_game();
+	assert(!scoreboard_get_home_penalty(0)->active);
+	assert(scoreboard_get_home_penalty(0)->phase2_tenths == 0);
+}
+
+static void test_compound_add_away_full(void)
+{
+	scoreboard_reset_state_for_tests();
+	for (int i = 0; i < SCOREBOARD_MAX_PENALTIES; i++)
+		scoreboard_away_penalty_add(i + 1, 120);
+	assert(scoreboard_away_penalty_add_compound(99, 120, 120) == -1);
+}
+
+static void test_away_penalty_set_time_inactive(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_away_penalty_set_time(0, 60);
+	assert(!scoreboard_get_away_penalty(0)->active);
+}
+
+static void test_away_penalty_set_time_zero_clears(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_away_penalty_add(22, 120);
+	scoreboard_away_penalty_add(15, 60);
+	scoreboard_away_penalty_set_time(0, 0);
+	/* After clear + compact: #15 moves to slot 0 */
+	assert(scoreboard_get_away_penalty(0)->player_number == 15);
+	assert(!scoreboard_get_away_penalty(1)->active);
+}
+
+static void test_set_time_zero_compound_transitions(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add_compound(12, 120, 120);
+	scoreboard_home_penalty_set_time(0, 0);
+	/* Should transition to phase 2, not clear */
+	const struct scoreboard_penalty *p = scoreboard_get_home_penalty(0);
+	assert(p->active);
+	assert(p->remaining_tenths == 1200);
+	assert(p->phase2_tenths == 0);
+}
+
+static void test_set_time_zero_compound_away_transitions(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_away_penalty_add_compound(22, 120, 300);
+	scoreboard_away_penalty_set_time(0, 0);
+	const struct scoreboard_penalty *p = scoreboard_get_away_penalty(0);
+	assert(p->active);
+	assert(p->remaining_tenths == 3000);
+	assert(p->phase2_tenths == 0);
+}
+
+static void test_set_time_zero_regular_still_clears(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add(12, 120);
+	scoreboard_home_penalty_set_time(0, 0);
+	assert(!scoreboard_get_home_penalty(0)->active);
+}
+
+static void test_regular_penalty_has_zero_phase2(void)
+{
+	scoreboard_reset_state_for_tests();
+	scoreboard_home_penalty_add(12, 120);
+	assert(scoreboard_get_home_penalty(0)->phase2_tenths == 0);
 }
 
 int main(void)
@@ -655,6 +1037,45 @@ int main(void)
 	test_queued_penalty_starts_after_expiry();
 	test_penalty_adjust_only_running();
 	test_format_only_running_penalties();
+
+	/* compact */
+	test_compact_fills_gap();
+	test_compact_no_gaps();
+	test_compact_empty();
+	test_compact_multiple_gaps();
+	test_compact_away();
+	test_tick_expire_compacts();
+	test_adjust_expire_compacts();
+	test_compact_preserves_phase2();
+
+	/* set_time */
+	test_home_penalty_set_time();
+	test_away_penalty_set_time();
+	test_penalty_set_time_invalid_slot();
+	test_penalty_set_time_inactive_slot();
+	test_penalty_set_time_zero_clears();
+	test_dirty_penalty_set_time();
+
+	/* compound penalties */
+	test_compound_add_home();
+	test_compound_add_away();
+	test_compound_add_full();
+	test_compound_phase_transition();
+	test_compound_phase2_expires();
+	test_compound_holds_slot();
+	test_compound_clear_removes_both();
+	test_compound_adjust_phase_transition();
+	test_compound_away_phase_transition();
+	test_compound_away_adjust_transition();
+	test_compound_counts_as_one_running();
+	test_compound_new_game_clears_phase2();
+	test_compound_add_away_full();
+	test_away_penalty_set_time_inactive();
+	test_away_penalty_set_time_zero_clears();
+	test_set_time_zero_compound_transitions();
+	test_set_time_zero_compound_away_transitions();
+	test_set_time_zero_regular_still_clears();
+	test_regular_penalty_has_zero_phase2();
 
 	printf("All scoreboard-core penalty tests passed.\n");
 	return 0;

--- a/tests/test-scoreboard-core-persistence.c
+++ b/tests/test-scoreboard-core-persistence.c
@@ -1206,6 +1206,86 @@ static void test_period_beyond_labels_format(void)
 	remove(tmpfile);
 }
 
+static void test_read_all_files_preserves_compound(void)
+{
+	scoreboard_reset_state_for_tests();
+	setup_tmp_dir();
+	scoreboard_set_output_directory(g_tmp_dir);
+
+	/* Add a compound penalty and a regular one */
+	scoreboard_home_penalty_add_compound(12, 120, 120);
+	scoreboard_home_penalty_add(7, 60);
+
+	/* Write text files (which don't carry phase2 info) */
+	bool ok = scoreboard_write_all_files();
+	assert(ok);
+
+	/* Re-read from files — should preserve phase2_tenths */
+	ok = scoreboard_read_all_files();
+	assert(ok);
+
+	const struct scoreboard_penalty *p = scoreboard_get_home_penalty(0);
+	assert(p->active);
+	assert(p->player_number == 12);
+	assert(p->phase2_tenths == 1200);
+
+	const struct scoreboard_penalty *p1 = scoreboard_get_home_penalty(1);
+	assert(p1->active);
+	assert(p1->player_number == 7);
+	assert(p1->phase2_tenths == 0);
+
+	cleanup_tmp_dir();
+}
+
+static void test_save_load_compound_penalty(void)
+{
+	scoreboard_reset_state_for_tests();
+	setup_tmp_dir();
+	scoreboard_home_penalty_add_compound(12, 120, 120);
+	scoreboard_away_penalty_add_compound(22, 120, 300);
+
+	char save_path[512];
+	snprintf(save_path, sizeof(save_path), "%s/state.json", g_tmp_dir);
+
+	assert(scoreboard_save_state(save_path));
+
+	scoreboard_reset_state_for_tests();
+	assert(scoreboard_load_state(save_path));
+
+	const struct scoreboard_penalty *hp = scoreboard_get_home_penalty(0);
+	assert(hp->active);
+	assert(hp->player_number == 12);
+	assert(hp->remaining_tenths == 1200);
+	assert(hp->phase2_tenths == 1200);
+
+	const struct scoreboard_penalty *ap = scoreboard_get_away_penalty(0);
+	assert(ap->active);
+	assert(ap->player_number == 22);
+	assert(ap->remaining_tenths == 1200);
+	assert(ap->phase2_tenths == 3000);
+
+	cleanup_tmp_dir();
+}
+
+static void test_load_old_json_no_phase2(void)
+{
+	scoreboard_reset_state_for_tests();
+	setup_tmp_dir();
+
+	/* Save state with a regular penalty (phase2_tenths will be 0) */
+	scoreboard_home_penalty_add(12, 120);
+	char save_path[512];
+	snprintf(save_path, sizeof(save_path), "%s/state.json", g_tmp_dir);
+	assert(scoreboard_save_state(save_path));
+
+	/* Reload — phase2_tenths defaults to 0 */
+	scoreboard_reset_state_for_tests();
+	assert(scoreboard_load_state(save_path));
+	assert(scoreboard_get_home_penalty(0)->phase2_tenths == 0);
+
+	cleanup_tmp_dir();
+}
+
 int main(void)
 {
 	test_write_all_files();
@@ -1257,6 +1337,9 @@ int main(void)
 	test_period_labels_save_load_zero_labels();
 	test_period_labels_load_exceeds_max();
 	test_period_beyond_labels_format();
+	test_read_all_files_preserves_compound();
+	test_save_load_compound_penalty();
+	test_load_old_json_no_phase2();
 
 	printf("All scoreboard-core persistence tests passed.\n");
 	return 0;

--- a/tests/test-scoreboard-core.c
+++ b/tests/test-scoreboard-core.c
@@ -383,6 +383,22 @@ static void test_clock_adjust_penalty_clears_at_zero(void)
 	assert(!scoreboard_get_home_penalty(0)->active);
 }
 
+static void test_clock_adjust_at_zero_no_penalty_change(void)
+{
+	/* When clock is already at 0, subtracting should not affect penalties */
+	scoreboard_reset_state_for_tests();
+	scoreboard_clock_set_tenths(0);
+	scoreboard_home_penalty_add(12, 120); /* 1200 tenths */
+
+	scoreboard_clock_adjust_seconds(-10);
+	assert(scoreboard_clock_get_tenths() == 0);
+	assert(scoreboard_get_home_penalty(0)->remaining_tenths == 1200);
+
+	scoreboard_clock_adjust_minutes(-1);
+	assert(scoreboard_clock_get_tenths() == 0);
+	assert(scoreboard_get_home_penalty(0)->remaining_tenths == 1200);
+}
+
 static void test_penalty_adjust_both_teams(void)
 {
 	scoreboard_reset_state_for_tests();
@@ -804,6 +820,7 @@ int main(void)
 	test_period_format_null();
 	test_clock_adjust_syncs_penalty();
 	test_clock_adjust_penalty_clears_at_zero();
+	test_clock_adjust_at_zero_no_penalty_change();
 	test_penalty_adjust_both_teams();
 	test_penalty_clear_after_adjust();
 	test_penalty_adjust_positive_delta();


### PR DESCRIPTION
## Summary

- **Compound penalties (2+2, 2+5, 2+10)**: Two-phase penalties where phase 2 auto-starts when phase 1 expires. Phase 2 toggles (+2, +5, +10) in the add-penalty dialog, only shown for sports with major penalties (hockey, lacrosse, rugby).
- **Slot consolidation**: After any penalty clear or expiry, remaining penalties pack to lowest slots — "Clear 1" always targets the first active penalty.
- **Penalty editing**: ✏ button and Edit 1/2 hotkeys open a dialog to change remaining time. Setting to 0 on a compound penalty transitions to phase 2.
- **Hotkey dialogs**: All penalty-add hotkeys now open a dialog for player number entry instead of silently adding numberless penalties.
- **Bug fixes**: Clock adjust at 0:00 no longer reduces penalty time; file watcher re-read no longer wipes compound phase data.

Bumps version to 0.6.0. Total OBS hotkeys: 37 → 45. 100% line coverage maintained on scoreboard-core.

## Test plan

- [ ] `make dev` — build + all 7 test suites pass
- [ ] `make coverage` — 100% line coverage on scoreboard-core.c
- [ ] `make install && make run` — manual testing in OBS:
  - [ ] Press minor/major hotkey → dialog opens, enter player #, confirm
  - [ ] Add 3 penalties → clear #1 → remaining shift to slots 1 and 2
  - [ ] Add 2+2 compound → phase 1 counts down → transitions to phase 2
  - [ ] Press X on compound in phase 1 → transitions to phase 2 (not full clear)
  - [ ] Edit penalty time via ✏ button → time updates
  - [ ] Switch sport to basketball → compound buttons hidden
  - [ ] Press -1 min when clock is at 0:00 → penalty time unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)